### PR TITLE
feat: Add native ERC20 token address endpoint

### DIFF
--- a/core/lib/web3_decl/src/namespaces/zks.rs
+++ b/core/lib/web3_decl/src/namespaces/zks.rs
@@ -37,6 +37,9 @@ pub trait ZksNamespace {
     #[method(name = "getMainContract")]
     async fn get_main_contract(&self) -> RpcResult<Address>;
 
+    #[method(name = "getNativeTokenAddress")]
+    async fn get_native_token_address(&self) -> RpcResult<Address>;
+
     #[method(name = "getTestnetPaymaster")]
     async fn get_testnet_paymaster(&self) -> RpcResult<Option<Address>>;
 

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/zks.rs
@@ -145,7 +145,7 @@ impl<G: L1GasPriceProvider + Send + Sync + 'static> ZksNamespaceT for ZksNamespa
         Box::pin(async move { Ok(self_.get_main_contract_impl()) })
     }
 
-    fn get_native_token_address(&self) -> BoxFuture<Result<Address> > {
+    fn get_native_token_address(&self) -> BoxFuture<Result<Address>> {
         todo!()
     }
 

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/zks.rs
@@ -33,6 +33,9 @@ pub trait ZksNamespaceT {
     #[rpc(name = "zks_getMainContract")]
     fn get_main_contract(&self) -> BoxFuture<Result<Address>>;
 
+    #[rpc(name = "zks_getNativeTokenAddress")]
+    fn get_native_token_address(&self) -> BoxFuture<Result<Address>>;
+
     #[rpc(name = "zks_getTestnetPaymaster")]
     fn get_testnet_paymaster(&self) -> BoxFuture<Result<Option<Address>>>;
 
@@ -140,6 +143,10 @@ impl<G: L1GasPriceProvider + Send + Sync + 'static> ZksNamespaceT for ZksNamespa
     fn get_main_contract(&self) -> BoxFuture<Result<Address>> {
         let self_ = self.clone();
         Box::pin(async move { Ok(self_.get_main_contract_impl()) })
+    }
+
+    fn get_native_token_address(&self) -> BoxFuture<Result<Address> > {
+        todo!()
     }
 
     fn get_miniblock_range(&self, batch: L1BatchNumber) -> BoxFuture<Result<Option<(U64, U64)>>> {

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/zks.rs
@@ -146,7 +146,12 @@ impl<G: L1GasPriceProvider + Send + Sync + 'static> ZksNamespaceT for ZksNamespa
     }
 
     fn get_native_token_address(&self) -> BoxFuture<Result<Address>> {
-        todo!()
+        let self_ = self.clone();
+        Box::pin(async move {
+            self_
+                .get_native_token_address_impl()
+                .map_err(into_jsrpc_error)
+        })
     }
 
     fn get_miniblock_range(&self, batch: L1BatchNumber) -> BoxFuture<Result<Option<(U64, U64)>>> {

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -39,7 +39,8 @@ impl<G: L1GasPriceProvider + Send + Sync + 'static> ZksNamespaceServer for ZksNa
     }
 
     async fn get_native_token_address(&self) -> RpcResult<Address> {
-        todo!()
+        self.get_native_token_address_impl()
+            .map_err(into_jsrpc_error)
     }
 
     async fn get_testnet_paymaster(&self) -> RpcResult<Option<Address>> {

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -38,6 +38,10 @@ impl<G: L1GasPriceProvider + Send + Sync + 'static> ZksNamespaceServer for ZksNa
         Ok(self.get_main_contract_impl())
     }
 
+    async fn get_native_token_address(&self) -> RpcResult<Address> {
+        todo!()
+    }
+
     async fn get_testnet_paymaster(&self) -> RpcResult<Option<Address>> {
         Ok(self.get_testnet_paymaster_impl())
     }

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -125,6 +125,11 @@ impl<G: L1GasPriceProvider> ZksNamespace<G> {
         self.state.api_config.diamond_proxy_addr
     }
 
+    #[tracing::instrument(skip_all)]
+    pub fn get_native_token_address_impl(&self) -> Address {
+        todo!()
+    }
+
     #[tracing::instrument(skip(self))]
     pub fn get_testnet_paymaster_impl(&self) -> Option<Address> {
         self.state.api_config.l2_testnet_paymaster_addr

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -132,14 +132,16 @@ impl<G: L1GasPriceProvider> ZksNamespace<G> {
 
         // read the address from the native_erc20.json file.
         // in the future it should be read from .init.env file
-        let native_erc20_file =
-            File::open(NATIVE_ERC20_FILE_PATH).map_err(|err| internal_error(METHOD_NAME, err))?;
+        let native_erc20_file = File::open(NATIVE_ERC20_FILE_PATH)
+            .map_err(|_err| internal_error(METHOD_NAME, "unable to read native_erc20.json file"))?;
         let native_erc20_json: serde_json::Value =
-            serde_json::from_reader(BufReader::new(native_erc20_file))
-                .map_err(|err| internal_error(METHOD_NAME, err))?;
+            serde_json::from_reader(BufReader::new(native_erc20_file)).map_err(|_err| {
+                internal_error(METHOD_NAME, "unable to read native_erc20.json file")
+            })?;
 
-        let native_erc20_address = native_erc20_json["address"]
-            .as_str()
+        let native_erc20_address = native_erc20_json
+            .get("address")
+            .and_then(|addr| addr.as_str())
             .ok_or_else(|| internal_error(METHOD_NAME, "address not found in json"))?;
 
         H160::from_str(native_erc20_address).map_err(|err| internal_error(METHOD_NAME, err))

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, convert::TryInto};
+use std::{collections::HashMap, convert::TryInto, fs::File, io::BufReader, str::FromStr};
 
 use bigdecimal::{BigDecimal, Zero};
 use zksync_dal::StorageProcessor;
@@ -15,9 +15,9 @@ use zksync_types::{
     l2_to_l1_log::L2ToL1Log,
     tokens::ETHEREUM_ADDRESS,
     transaction_request::CallRequest,
-    AccountTreeId, L1BatchNumber, MiniblockNumber, StorageKey, Transaction, L1_MESSENGER_ADDRESS,
-    L2_ETH_TOKEN_ADDRESS, MAX_GAS_PER_PUBDATA_BYTE, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256,
-    U64,
+    AccountTreeId, L1BatchNumber, MiniblockNumber, StorageKey, Transaction, H160,
+    L1_MESSENGER_ADDRESS, L2_ETH_TOKEN_ADDRESS, MAX_GAS_PER_PUBDATA_BYTE,
+    REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256, U64,
 };
 use zksync_utils::{address_to_h256, ratio_to_big_decimal_normalized};
 use zksync_web3_decl::{
@@ -126,8 +126,23 @@ impl<G: L1GasPriceProvider> ZksNamespace<G> {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn get_native_token_address_impl(&self) -> Address {
-        todo!()
+    pub fn get_native_token_address_impl(&self) -> Result<Address, Web3Error> {
+        const METHOD_NAME: &str = "get_native_token_address";
+        const NATIVE_ERC20_FILE_PATH: &str = "etc/tokens/native_erc20.json";
+
+        // read the address from the native_erc20.json file.
+        // in the future it should be read from .init.env file
+        let native_erc20_file =
+            File::open(NATIVE_ERC20_FILE_PATH).map_err(|err| internal_error(METHOD_NAME, err))?;
+        let native_erc20_json: serde_json::Value =
+            serde_json::from_reader(BufReader::new(native_erc20_file))
+                .map_err(|err| internal_error(METHOD_NAME, err))?;
+
+        let native_erc20_address = native_erc20_json["address"]
+            .as_str()
+            .ok_or_else(|| internal_error(METHOD_NAME, "address not found in json"))?;
+
+        H160::from_str(native_erc20_address).map_err(|err| internal_error(METHOD_NAME, err))
     }
 
     #[tracing::instrument(skip(self))]


### PR DESCRIPTION
## What ❔
Adds a new RPC endpoint to get the Address of the native ERC20

<!-- What are the changes this PR brings about? -->
it only adds a new method in the zks namespace.

## Why ❔
This is needed by the explorer. More context here: https://github.com/lambdaclass/zksync-era/issues/31

## How to test
You first need to run `zk init --native-erc20` to deploy the required contracts and generate the native_erc20.json file.
Then run the following command:
```bash
$ curl -X POST localhost:3050 -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"zks_getNativeTokenAddress", "params":[], "id":1}'

# expected output:
{"jsonrpc":"2.0","result":"0x2be576fb1996aeca500460c6691ce594a0aa98ae","id":1}
```
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
