### PR TITLE
feat: set native token env var

### DIFF
--- a/core/tests/ts-integration/src/env.ts
+++ b/core/tests/ts-integration/src/env.ts
@@ -48,7 +48,7 @@ export async function waitForServer() {
  */
 export async function loadTestEnvironment(): Promise<TestEnvironment> {
     const network = process.env.CHAIN_ETH_NETWORK || 'localhost';
-    const nativeErc20Testing = process.env.NATIVE_ERC20_ADDRESS ? true : false; // if set, we assume user wants to test native erc20 tokens
+    const nativeErc20Testing = process.env.CONTRACTS_L1_NATIVE_ERC20_TOKEN_ADDR ? true : false; // if set, we assume user wants to test native erc20 tokens
 
     let mainWalletPK;
     if (nativeErc20Testing) {

--- a/infrastructure/zk/src/hyperchain_wizard.ts
+++ b/infrastructure/zk/src/hyperchain_wizard.ts
@@ -630,6 +630,19 @@ export function getTokens(network: string): L1Token[] {
     }
 }
 
+export function getNativeToken(): L1Token {
+    const configPath = `${process.env.ZKSYNC_HOME}/etc/tokens/native_erc20.json`;
+    try {
+        return JSON.parse(
+            fs.readFileSync(configPath, {
+                encoding: 'utf-8'
+            })
+        );
+    } catch (e) {
+        throw e;
+    }
+}
+
 async function selectHyperchainConfiguration() {
     const envs = env.getAvailableEnvsFromFiles();
 

--- a/infrastructure/zk/src/hyperchain_wizard.ts
+++ b/infrastructure/zk/src/hyperchain_wizard.ts
@@ -632,15 +632,11 @@ export function getTokens(network: string): L1Token[] {
 
 export function getNativeToken(): L1Token {
     const configPath = `${process.env.ZKSYNC_HOME}/etc/tokens/native_erc20.json`;
-    try {
-        return JSON.parse(
-            fs.readFileSync(configPath, {
-                encoding: 'utf-8'
-            })
-        );
-    } catch (e) {
-        throw e;
-    }
+    return JSON.parse(
+        fs.readFileSync(configPath, {
+            encoding: 'utf-8'
+        })
+    );
 }
 
 async function selectHyperchainConfiguration() {

--- a/infrastructure/zk/src/run/run.ts
+++ b/infrastructure/zk/src/run/run.ts
@@ -4,7 +4,7 @@ import { Wallet } from 'ethers';
 import fs from 'fs';
 import * as path from 'path';
 import * as dataRestore from './data-restore';
-import { getTokens } from '../hyperchain_wizard';
+import { getNativeToken, getTokens } from '../hyperchain_wizard';
 import * as env from '../env';
 import { IERC20Factory } from 'zksync-web3/build/typechain';
 import { Provider } from 'zksync-web3';
@@ -50,9 +50,17 @@ export async function deployERC20(
         env.modify('CONTRACTS_L1_WETH_TOKEN_ADDR', `CONTRACTS_L1_WETH_TOKEN_ADDR=${WETH.address}`);
     } else if (command == 'new') {
         let destinationFile = 'native_erc20';
-        await utils.spawn(
-            `yarn --silent --cwd contracts/ethereum deploy-erc20 add --token-name ${name} --symbol ${symbol} --decimals ${decimals} > ./etc/tokens/${destinationFile}.json`
-        );
+        await utils
+            .spawn(
+                `yarn --silent --cwd contracts/ethereum deploy-erc20 add --token-name ${name} --symbol ${symbol} --decimals ${decimals} > ./etc/tokens/${destinationFile}.json`
+            )
+            .then(() => {
+                const NATIVE_ERC20 = getNativeToken();
+                env.modify(
+                    'CONTRACTS_L1_NATIVE_ERC20_TOKEN_ADDR',
+                    `CONTRACTS_L1_NATIVE_ERC20_TOKEN_ADDR=${NATIVE_ERC20.address}`
+                );
+            });
     }
 }
 


### PR DESCRIPTION
## What ❔

Set a native token environment variable: `CONTRACTS_L1_NATIVE_ERC20_TOKEN_ADDR` on native token deployment.

**Note:** with the current implementation, if the previously mentioned env var is set, testing will be done with native token variables.

## Why ❔

Prevent user from having to set token related environment variables manually, which is error prone.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
