### PR TITLE
feat: Add `zks_getL1BatchPubdata` endpoint

### DIFF
--- a/core/lib/dal/sqlx-data.json
+++ b/core/lib/dal/sqlx-data.json
@@ -1,0 +1,3 @@
+{
+  "db": "PostgreSQL"
+}

--- a/core/lib/dal/src/blocks_dal.rs
+++ b/core/lib/dal/src/blocks_dal.rs
@@ -2146,6 +2146,45 @@ impl BlocksDal<'_, '_> {
         .await?
         .map(|row| row.virtual_blocks as u32))
     }
+
+    pub async fn get_l1_batch_pubdata(
+        &mut self,
+        l1_batch_number: L1BatchNumber,
+    ) -> sqlx::Result<Vec<u8>> {
+        let l1_batch_header = self.get_l1_batch_header(l1_batch_number).await?.unwrap();
+        let l1_batch_metadata = self
+            .get_l1_batch_metadata(l1_batch_number)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let mut res = Vec::new();
+
+        // Process and Pack Logs
+        res.extend((l1_batch_header.l2_to_l1_logs.len() as u32).to_be_bytes());
+        for l2_to_l1_log in &l1_batch_header.l2_to_l1_logs {
+            res.extend(l2_to_l1_log.0.to_bytes());
+        }
+
+        // Process and Pack Messages
+        res.extend((l1_batch_header.l2_to_l1_messages.len() as u32).to_be_bytes());
+        for msg in &l1_batch_header.l2_to_l1_messages {
+            res.extend((msg.len() as u32).to_be_bytes());
+            res.extend(msg);
+        }
+
+        // Process and Pack Bytecodes
+        res.extend((l1_batch_metadata.factory_deps.len() as u32).to_be_bytes());
+        for bytecode in &l1_batch_metadata.factory_deps {
+            res.extend((bytecode.len() as u32).to_be_bytes());
+            res.extend(bytecode);
+        }
+
+        // Extend with Compressed StateDiffs
+        res.extend(&l1_batch_metadata.metadata.state_diffs_compressed);
+
+        Ok(res)
+    }
 }
 
 /// These functions should only be used for tests.

--- a/core/lib/web3_decl/src/namespaces/zks.rs
+++ b/core/lib/web3_decl/src/namespaces/zks.rs
@@ -118,4 +118,7 @@ pub trait ZksNamespace {
         keys: Vec<H256>,
         l1_batch_number: L1BatchNumber,
     ) -> RpcResult<Proof>;
+
+    #[method(name = "getL1BatchPubdata")]
+    async fn get_l1_batch_pubdata(&self, l1_batch_number: L1BatchNumber) -> RpcResult<Vec<u8>>;
 }

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -168,4 +168,10 @@ impl ZksNamespaceServer for ZksNamespace {
             .await
             .map_err(into_jsrpc_error)
     }
+
+    async fn get_l1_batch_pubdata(&self, l1_batch_number: L1BatchNumber) -> RpcResult<Vec<u8>> {
+        self.get_l1_batch_pubdata_impl(l1_batch_number)
+            .await
+            .map_err(into_jsrpc_error)
+    }
 }

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -642,4 +642,24 @@ impl ZksNamespace {
             storage_proof,
         })
     }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn get_l1_batch_pubdata_impl(
+        &self,
+        l1_batch_number: L1BatchNumber,
+    ) -> Result<Vec<u8>, Web3Error> {
+        const METHOD_NAME: &str = "get_l1_batch_pubdata";
+
+        let method_latency = API_METRICS.start_call(METHOD_NAME);
+        self.state.start_info.ensure_not_pruned(l1_batch_number)?;
+        let mut storage = self.access_storage(METHOD_NAME).await?;
+        let pubdata = storage
+            .blocks_dal()
+            .get_l1_batch_pubdata(l1_batch_number)
+            .await
+            .map_err(|err| internal_error(METHOD_NAME, err))?;
+
+        method_latency.observe();
+        Ok(pubdata)
+    }
 }


### PR DESCRIPTION
## Description

This PR adds an endpoint to the RPC that'll let a user like Validium's DA Manager get some batch's pubdata to store in some DA Layer.

## How to test

1. Run the hole stack (`zk && zk clean --all && zk init`)
2. Run the following `curl`
```
curl http://localhost:3050  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"zks_getL1BatchPubdata","params":[1],"id":1,"jsonrpc":"2.0"}'
```