### PR TITLE
fix: missing structure fields in 'testonly.rs' 

### DIFF
--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -483,6 +483,7 @@ impl RandomConfig for configs::eth_sender::GasAdjusterConfig {
             internal_enforced_l1_gas_price: g.gen(),
             poll_period: g.gen(),
             max_l1_gas_price: g.gen(),
+            l1_gas_per_pubdata_byte: g.gen(),
         }
     }
 }


### PR DESCRIPTION
Fix:


```
   Compiling zksync_config v0.1.0 (/zksync/zksync-era-lambda/core/lib/config)
error[E0063]: missing field `l1_gas_per_pubdata_byte` in initializer of `GasAdjusterConfig`
   --> core/lib/config/src/testonly.rs:477:9
    |
477 |         Self {
    |         ^^^^ missing `l1_gas_per_pubdata_byte`

For more information about this error, try `rustc --explain E0063`.
error: could not compile `zksync_config` (lib) due to previous error
error: `cargo check` failed with status: exit status: 101
``` 