### PR TITLE
fix: Delete unused config files in validium pubdata abstraction 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9909,7 +9909,6 @@ version = "0.1.0"
 dependencies = [
  "codegen 0.1.0",
  "zkevm_test_harness 1.3.3",
- "zksync_config",
  "zksync_prover_interface",
  "zksync_types",
 ]

--- a/core/lib/dal/sqlx-data.json
+++ b/core/lib/dal/sqlx-data.json
@@ -1,3 +1,0 @@
-{
-  "db": "PostgreSQL"
-}

--- a/core/lib/l1_contract_interface/Cargo.toml
+++ b/core/lib/l1_contract_interface/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 [dependencies]
 zksync_types = { path = "../types" }
 zksync_prover_interface = { path = "../prover_interface" }
-zksync_config = { path = "../config" }
 
 # Used to serialize proof data
 codegen = { git = "https://github.com/matter-labs/solidity_plonk_verifier.git", branch = "dev" }

--- a/core/lib/types/src/l1_batch_commit_data_generator.rs
+++ b/core/lib/types/src/l1_batch_commit_data_generator.rs
@@ -10,10 +10,10 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct RollupModeL1BatchCommitDataGenerator {}
+pub struct RollupModeL1BatchCommitDataGenerator;
 
 #[derive(Debug, Clone)]
-pub struct ValidiumModeL1BatchCommitDataGenerator {}
+pub struct ValidiumModeL1BatchCommitDataGenerator;
 
 impl L1BatchCommitDataGenerator for RollupModeL1BatchCommitDataGenerator {
     fn l1_commit_data(&self, l1_batch_with_metadata: &L1BatchWithMetadata) -> Token {


### PR DESCRIPTION
## Issues 
Merging this PR fixes: #111, #108, #109 and #110 
## What ❔
Removing `era-contracts-lambda` submodule as it is no longer necessary. Also removing `zksync-config` crate from `l1-contract-interface` as it is not used anymore. 
There is also a sql file created in the initialisation that should not be tracked. 
Finally there is a nit where empty structs don't need braces so it removes them. 

## Why ❔
Removing unnecessary imports and repository files.

## Description ❕
This pull request aims to streamline the repository by removing the now unnecessary `era-contracts-lambda` submodule and the `zksync-config` crate from `l1-contract-interface`. These changes have been made to clean up the codebase, removing unused dependencies and files.

## Expected Behavior ❗
After applying these changes, running the following commands should complete successfully without any issues:

```bash
zk
zk clean --all
zk init --validium-mode
zk server