### PR TITLE
feat: adapt `consistency_checker` tests for running both in Validium mode and Rollup mode

### DIFF
--- a/core/lib/types/src/l1_batch_commit_data_generator.rs
+++ b/core/lib/types/src/l1_batch_commit_data_generator.rs
@@ -23,7 +23,9 @@ impl L1BatchCommitDataGenerator for RollupModeL1BatchCommitDataGenerator {
 
 impl L1BatchCommitDataGenerator for ValidiumModeL1BatchCommitDataGenerator {
     fn l1_commit_data(&self, l1_batch_with_metadata: &L1BatchWithMetadata) -> Token {
-        Token::Tuple(validium_mode_l1_commit_data(l1_batch_with_metadata))
+        let mut commit_data = validium_mode_l1_commit_data(l1_batch_with_metadata);
+        commit_data.push(Token::Bytes([0].to_vec()));
+        Token::Tuple(commit_data)
     }
 }
 

--- a/core/lib/types/src/l1_batch_commit_data_generator.rs
+++ b/core/lib/types/src/l1_batch_commit_data_generator.rs
@@ -23,9 +23,7 @@ impl L1BatchCommitDataGenerator for RollupModeL1BatchCommitDataGenerator {
 
 impl L1BatchCommitDataGenerator for ValidiumModeL1BatchCommitDataGenerator {
     fn l1_commit_data(&self, l1_batch_with_metadata: &L1BatchWithMetadata) -> Token {
-        let mut commit_data = validium_mode_l1_commit_data(l1_batch_with_metadata);
-        commit_data.push(Token::Bytes([0].to_vec()));
-        Token::Tuple(commit_data)
+        Token::Tuple(validium_mode_l1_commit_data(l1_batch_with_metadata))
     }
 }
 

--- a/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
@@ -1,4 +1,5 @@
 //! Tests for the consistency checker component.
+mod test_helpers;
 
 use std::{collections::HashMap, slice};
 
@@ -15,17 +16,14 @@ use zksync_types::{
         RollupModeL1BatchCommitDataGenerator, ValidiumModeL1BatchCommitDataGenerator,
     },
     web3::contract::Options,
-    L2ChainId, ProtocolVersion, ProtocolVersionId, H256,
+    ProtocolVersionId, H256,
 };
 
 use super::*;
-use crate::{
-    genesis::{ensure_genesis_state, GenesisParams},
-    utils::testonly::{create_l1_batch, create_l1_batch_metadata},
-};
+use crate::utils::testonly::{create_l1_batch, create_l1_batch_metadata};
 
 /// **NB.** For tests to run correctly, the returned value must be deterministic (i.e., depend only on `number`).
-fn create_l1_batch_with_metadata(number: u32) -> L1BatchWithMetadata {
+pub(crate) fn create_l1_batch_with_metadata(number: u32) -> L1BatchWithMetadata {
     L1BatchWithMetadata {
         header: create_l1_batch(number),
         metadata: create_l1_batch_metadata(number),
@@ -35,7 +33,7 @@ fn create_l1_batch_with_metadata(number: u32) -> L1BatchWithMetadata {
 
 const PRE_BOOJUM_PROTOCOL_VERSION: ProtocolVersionId = ProtocolVersionId::Version10;
 
-fn create_pre_boojum_l1_batch_with_metadata(number: u32) -> L1BatchWithMetadata {
+pub(crate) fn create_pre_boojum_l1_batch_with_metadata(number: u32) -> L1BatchWithMetadata {
     let mut l1_batch = L1BatchWithMetadata {
         header: create_l1_batch(number),
         metadata: create_l1_batch_metadata(number),
@@ -47,7 +45,7 @@ fn create_pre_boojum_l1_batch_with_metadata(number: u32) -> L1BatchWithMetadata 
     l1_batch
 }
 
-fn build_commit_tx_input_data(
+pub(crate) fn build_commit_tx_input_data(
     batches: &[L1BatchWithMetadata],
     l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
 ) -> Vec<u8> {
@@ -67,7 +65,10 @@ fn build_commit_tx_input_data(
     encoded
 }
 
-fn create_mock_checker(client: MockEthereum, pool: ConnectionPool) -> ConsistencyChecker {
+pub(crate) fn create_mock_checker(
+    client: MockEthereum,
+    pool: ConnectionPool,
+) -> ConsistencyChecker {
     ConsistencyChecker {
         contract: zksync_contracts::zksync_contract(),
         max_batches_to_recheck: 100,
@@ -85,38 +86,14 @@ impl UpdateCheckedBatch for mpsc::UnboundedSender<L1BatchNumber> {
     }
 }
 
-fn _build_commit_tx_input_data_is_correct(
-    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
-) {
-    let contract = zksync_contracts::zksync_contract();
-    let commit_function = contract.function("commitBatches").unwrap();
-    let batches = vec![
-        create_l1_batch_with_metadata(1),
-        create_l1_batch_with_metadata(2),
-    ];
-
-    let commit_tx_input_data =
-        build_commit_tx_input_data(&batches, l1_batch_commit_data_generator.clone());
-
-    for batch in &batches {
-        let commit_data = ConsistencyChecker::extract_commit_data(
-            &commit_tx_input_data,
-            commit_function,
-            batch.header.number,
-        )
-        .unwrap();
-        assert_eq!(
-            commit_data,
-            CommitBatchInfo::new(batch, l1_batch_commit_data_generator.clone().clone())
-                .into_token()
-        );
-    }
-}
-
 #[test]
 fn build_commit_tx_input_data_is_correct() {
-    _build_commit_tx_input_data_is_correct(Arc::new(RollupModeL1BatchCommitDataGenerator {}));
-    _build_commit_tx_input_data_is_correct(Arc::new(ValidiumModeL1BatchCommitDataGenerator {}));
+    test_helpers::build_commit_tx_input_data_is_correct(Arc::new(
+        RollupModeL1BatchCommitDataGenerator {},
+    ));
+    test_helpers::build_commit_tx_input_data_is_correct(Arc::new(
+        ValidiumModeL1BatchCommitDataGenerator {},
+    ));
 }
 
 #[test]
@@ -201,7 +178,7 @@ fn extracting_commit_data_for_pre_boojum_batch() {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum SaveAction<'a> {
+pub enum SaveAction<'a> {
     InsertBatch(&'a L1BatchWithMetadata),
     SaveMetadata(&'a L1BatchWithMetadata),
     InsertCommitTx(L1BatchNumber),
@@ -250,7 +227,7 @@ impl SaveAction<'_> {
     }
 }
 
-type SaveActionMapper = fn(&[L1BatchWithMetadata]) -> Vec<SaveAction<'_>>;
+pub(crate) type SaveActionMapper = fn(&[L1BatchWithMetadata]) -> Vec<SaveAction<'_>>;
 
 /// Various strategies to persist L1 batches in the DB. Strings are added for debugging failed test cases.
 const SAVE_ACTION_MAPPERS: [(&str, SaveActionMapper); 4] = [
@@ -302,169 +279,24 @@ const SAVE_ACTION_MAPPERS: [(&str, SaveActionMapper); 4] = [
     }),
 ];
 
-async fn _normal_checker_function(
-    batches_per_transaction: usize,
-    (mapper_name, save_actions_mapper): (&'static str, SaveActionMapper),
-    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
-) {
-    println!("Using save_actions_mapper={mapper_name}");
-
-    let pool = ConnectionPool::test_pool().await;
-    let mut storage = pool.access_storage().await.unwrap();
-    ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
-        .await
-        .unwrap();
-
-    let l1_batches: Vec<_> = (1..=10).map(create_l1_batch_with_metadata).collect();
-    let mut commit_tx_hash_by_l1_batch = HashMap::with_capacity(l1_batches.len());
-    let client = MockEthereum::default();
-
-    for (i, l1_batches) in l1_batches.chunks(batches_per_transaction).enumerate() {
-        let input_data =
-            build_commit_tx_input_data(l1_batches, l1_batch_commit_data_generator.clone());
-        let signed_tx = client.sign_prepared_tx(
-            input_data.clone(),
-            Options {
-                nonce: Some(i.into()),
-                ..Options::default()
-            },
-        );
-        let signed_tx = signed_tx.unwrap();
-        client.send_raw_tx(signed_tx.raw_tx).await.unwrap();
-        client.execute_tx(signed_tx.hash, true, 1);
-
-        commit_tx_hash_by_l1_batch.extend(
-            l1_batches
-                .iter()
-                .map(|batch| (batch.header.number, signed_tx.hash)),
-        );
-    }
-
-    let (l1_batch_updates_sender, mut l1_batch_updates_receiver) = mpsc::unbounded_channel();
-    let checker = ConsistencyChecker {
-        l1_batch_updater: Box::new(l1_batch_updates_sender),
-        ..create_mock_checker(client, pool.clone())
-    };
-
-    let (stop_sender, stop_receiver) = watch::channel(false);
-    let checker_task =
-        tokio::spawn(checker.run(stop_receiver, l1_batch_commit_data_generator.clone()));
-
-    // Add new batches to the storage.
-    for save_action in save_actions_mapper(&l1_batches) {
-        save_action
-            .apply(&mut storage, &commit_tx_hash_by_l1_batch)
-            .await;
-        tokio::time::sleep(Duration::from_millis(7)).await;
-    }
-
-    // Wait until all batches are checked.
-    loop {
-        let checked_batch = l1_batch_updates_receiver.recv().await.unwrap();
-        if checked_batch == l1_batches.last().unwrap().header.number {
-            break;
-        }
-    }
-
-    // Send the stop signal to the checker and wait for it to stop.
-    stop_sender.send_replace(true);
-    checker_task.await.unwrap().unwrap();
-}
-
 #[test_casing(12, Product(([10, 3, 1], SAVE_ACTION_MAPPERS)))]
 #[tokio::test]
 async fn normal_checker_function(
     batches_per_transaction: usize,
     (mapper_name, save_actions_mapper): (&'static str, SaveActionMapper),
 ) {
-    _normal_checker_function(
+    test_helpers::normal_checker_function(
         batches_per_transaction,
         (mapper_name, save_actions_mapper),
         Arc::new(RollupModeL1BatchCommitDataGenerator {}),
     )
     .await;
-    _normal_checker_function(
+    test_helpers::normal_checker_function(
         batches_per_transaction,
         (mapper_name, save_actions_mapper),
         Arc::new(ValidiumModeL1BatchCommitDataGenerator {}),
     )
     .await;
-}
-
-async fn _checker_processes_pre_boojum_batches(
-    (mapper_name, save_actions_mapper): (&'static str, SaveActionMapper),
-    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
-) {
-    println!("Using save_actions_mapper={mapper_name}");
-
-    let pool = ConnectionPool::test_pool().await;
-    let mut storage = pool.access_storage().await.unwrap();
-    let genesis_params = GenesisParams {
-        protocol_version: PRE_BOOJUM_PROTOCOL_VERSION,
-        ..GenesisParams::mock()
-    };
-    ensure_genesis_state(&mut storage, L2ChainId::default(), &genesis_params)
-        .await
-        .unwrap();
-    storage
-        .protocol_versions_dal()
-        .save_protocol_version_with_tx(ProtocolVersion::default())
-        .await;
-
-    let l1_batches: Vec<_> = (1..=5)
-        .map(create_pre_boojum_l1_batch_with_metadata)
-        .chain((6..=10).map(create_l1_batch_with_metadata))
-        .collect();
-    let mut commit_tx_hash_by_l1_batch = HashMap::with_capacity(l1_batches.len());
-    let client = MockEthereum::default();
-
-    for (i, l1_batch) in l1_batches.iter().enumerate() {
-        let input_data = build_commit_tx_input_data(
-            slice::from_ref(l1_batch),
-            l1_batch_commit_data_generator.clone(),
-        );
-        let signed_tx = client.sign_prepared_tx(
-            input_data.clone(),
-            Options {
-                nonce: Some(i.into()),
-                ..Options::default()
-            },
-        );
-        let signed_tx = signed_tx.unwrap();
-        client.send_raw_tx(signed_tx.raw_tx).await.unwrap();
-        client.execute_tx(signed_tx.hash, true, 1);
-
-        commit_tx_hash_by_l1_batch.insert(l1_batch.header.number, signed_tx.hash);
-    }
-
-    let (l1_batch_updates_sender, mut l1_batch_updates_receiver) = mpsc::unbounded_channel();
-    let checker = ConsistencyChecker {
-        l1_batch_updater: Box::new(l1_batch_updates_sender),
-        ..create_mock_checker(client, pool.clone())
-    };
-
-    let (stop_sender, stop_receiver) = watch::channel(false);
-    let checker_task = tokio::spawn(checker.run(stop_receiver, l1_batch_commit_data_generator));
-
-    // Add new batches to the storage.
-    for save_action in save_actions_mapper(&l1_batches) {
-        save_action
-            .apply(&mut storage, &commit_tx_hash_by_l1_batch)
-            .await;
-        tokio::time::sleep(Duration::from_millis(7)).await;
-    }
-
-    // Wait until all batches are checked.
-    loop {
-        let checked_batch = l1_batch_updates_receiver.recv().await.unwrap();
-        if checked_batch == l1_batches.last().unwrap().header.number {
-            break;
-        }
-    }
-
-    // Send the stop signal to the checker and wait for it to stop.
-    stop_sender.send_replace(true);
-    checker_task.await.unwrap().unwrap();
 }
 
 #[test_casing(4, SAVE_ACTION_MAPPERS)]
@@ -472,97 +304,27 @@ async fn _checker_processes_pre_boojum_batches(
 async fn checker_processes_pre_boojum_batches(
     (mapper_name, save_actions_mapper): (&'static str, SaveActionMapper),
 ) {
-    _checker_processes_pre_boojum_batches(
+    test_helpers::checker_processes_pre_boojum_batches(
         (mapper_name, save_actions_mapper),
         Arc::new(RollupModeL1BatchCommitDataGenerator {}),
     )
     .await;
-    _checker_processes_pre_boojum_batches(
+    test_helpers::checker_processes_pre_boojum_batches(
         (mapper_name, save_actions_mapper),
         Arc::new(ValidiumModeL1BatchCommitDataGenerator {}),
     )
     .await;
 }
 
-async fn _checker_functions_after_snapshot_recovery(
-    delay_batch_insertion: bool,
-    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
-) {
-    let pool = ConnectionPool::test_pool().await;
-    let mut storage = pool.access_storage().await.unwrap();
-    storage
-        .protocol_versions_dal()
-        .save_protocol_version_with_tx(ProtocolVersion::default())
-        .await;
-
-    let l1_batch = create_l1_batch_with_metadata(99);
-
-    let commit_tx_input_data = build_commit_tx_input_data(
-        slice::from_ref(&l1_batch),
-        l1_batch_commit_data_generator.clone(),
-    );
-    let client = MockEthereum::default();
-    let signed_tx = client.sign_prepared_tx(
-        commit_tx_input_data.clone(),
-        Options {
-            nonce: Some(0.into()),
-            ..Options::default()
-        },
-    );
-    let signed_tx = signed_tx.unwrap();
-    let commit_tx_hash = signed_tx.hash;
-    client.send_raw_tx(signed_tx.raw_tx).await.unwrap();
-    client.execute_tx(commit_tx_hash, true, 1);
-
-    let save_actions = [
-        SaveAction::InsertBatch(&l1_batch),
-        SaveAction::SaveMetadata(&l1_batch),
-        SaveAction::InsertCommitTx(l1_batch.header.number),
-    ];
-    let commit_tx_hash_by_l1_batch = HashMap::from([(l1_batch.header.number, commit_tx_hash)]);
-
-    if !delay_batch_insertion {
-        for &save_action in &save_actions {
-            save_action
-                .apply(&mut storage, &commit_tx_hash_by_l1_batch)
-                .await;
-        }
-    }
-
-    let (l1_batch_updates_sender, mut l1_batch_updates_receiver) = mpsc::unbounded_channel();
-    let checker = ConsistencyChecker {
-        l1_batch_updater: Box::new(l1_batch_updates_sender),
-        ..create_mock_checker(client, pool.clone())
-    };
-    let (stop_sender, stop_receiver) = watch::channel(false);
-    let checker_task = tokio::spawn(checker.run(stop_receiver, l1_batch_commit_data_generator));
-
-    if delay_batch_insertion {
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        for &save_action in &save_actions {
-            save_action
-                .apply(&mut storage, &commit_tx_hash_by_l1_batch)
-                .await;
-        }
-    }
-
-    // Wait until the batch is checked.
-    let checked_batch = l1_batch_updates_receiver.recv().await.unwrap();
-    assert_eq!(checked_batch, l1_batch.header.number);
-
-    stop_sender.send_replace(true);
-    checker_task.await.unwrap().unwrap();
-}
-
 #[test_casing(2, [false, true])]
 #[tokio::test]
 async fn checker_functions_after_snapshot_recovery(delay_batch_insertion: bool) {
-    _checker_functions_after_snapshot_recovery(
+    test_helpers::checker_functions_after_snapshot_recovery(
         delay_batch_insertion,
         Arc::new(RollupModeL1BatchCommitDataGenerator {}),
     )
     .await;
-    _checker_functions_after_snapshot_recovery(
+    test_helpers::checker_functions_after_snapshot_recovery(
         delay_batch_insertion,
         Arc::new(ValidiumModeL1BatchCommitDataGenerator {}),
     )
@@ -570,7 +332,7 @@ async fn checker_functions_after_snapshot_recovery(delay_batch_insertion: bool) 
 }
 
 #[derive(Debug, Clone, Copy)]
-enum IncorrectDataKind {
+pub enum IncorrectDataKind {
     MissingStatus,
     MismatchedStatus,
     BogusCommitDataFormat,
@@ -654,66 +416,17 @@ impl IncorrectDataKind {
     }
 }
 
-async fn _checker_detects_incorrect_tx_data(
-    kind: IncorrectDataKind,
-    snapshot_recovery: bool,
-    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
-) {
-    let pool = ConnectionPool::test_pool().await;
-    let mut storage = pool.access_storage().await.unwrap();
-    if snapshot_recovery {
-        storage
-            .protocol_versions_dal()
-            .save_protocol_version_with_tx(ProtocolVersion::default())
-            .await;
-    } else {
-        ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
-            .await
-            .unwrap();
-    }
-
-    let l1_batch = create_l1_batch_with_metadata(if snapshot_recovery { 99 } else { 1 });
-    let client = MockEthereum::default();
-    let commit_tx_hash = kind
-        .apply(&client, &l1_batch, l1_batch_commit_data_generator.clone())
-        .await;
-    let commit_tx_hash_by_l1_batch = HashMap::from([(l1_batch.header.number, commit_tx_hash)]);
-
-    let save_actions = [
-        SaveAction::InsertBatch(&l1_batch),
-        SaveAction::SaveMetadata(&l1_batch),
-        SaveAction::InsertCommitTx(l1_batch.header.number),
-    ];
-    for save_action in save_actions {
-        save_action
-            .apply(&mut storage, &commit_tx_hash_by_l1_batch)
-            .await;
-    }
-    drop(storage);
-
-    let checker = create_mock_checker(client, pool);
-    let (_stop_sender, stop_receiver) = watch::channel(false);
-    // The checker must stop with an error.
-    tokio::time::timeout(
-        Duration::from_secs(30),
-        checker.run(stop_receiver, l1_batch_commit_data_generator),
-    )
-    .await
-    .expect("Timed out waiting for checker to stop")
-    .unwrap_err();
-}
-
 #[test_casing(6, Product((IncorrectDataKind::ALL, [false])))]
 // ^ `snapshot_recovery = true` is tested below; we don't want to run it with all incorrect data kinds
 #[tokio::test]
 async fn checker_detects_incorrect_tx_data(kind: IncorrectDataKind, snapshot_recovery: bool) {
-    _checker_detects_incorrect_tx_data(
+    test_helpers::checker_detects_incorrect_tx_data(
         kind,
         snapshot_recovery,
         Arc::new(RollupModeL1BatchCommitDataGenerator {}),
     )
     .await;
-    _checker_detects_incorrect_tx_data(
+    test_helpers::checker_detects_incorrect_tx_data(
         kind,
         snapshot_recovery,
         Arc::new(ValidiumModeL1BatchCommitDataGenerator {}),

--- a/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
@@ -119,7 +119,8 @@ fn build_commit_tx_input_data_is_correct() {
     _build_commit_tx_input_data_is_correct(Arc::new(ValidiumModeL1BatchCommitDataGenerator {}));
 }
 
-fn _extracting_commit_data_for_boojum_batch() {
+#[test]
+fn extracting_commit_data_for_boojum_batch() {
     let contract = zksync_contracts::zksync_contract();
     let commit_function = contract.function("commitBatches").unwrap();
     // Calldata taken from the commit transaction for `https://sepolia.explorer.zksync.io/batch/4470`;
@@ -146,11 +147,6 @@ fn _extracting_commit_data_for_boojum_batch() {
         )
         .unwrap_err();
     }
-}
-
-#[test]
-fn extracting_commit_data_for_boojum_batch() {
-    _extracting_commit_data_for_boojum_batch();
 }
 
 #[test]

--- a/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
@@ -488,9 +488,10 @@ async fn checker_processes_pre_boojum_batches(
     .await;
 }
 
-#[test_casing(2, [false, true])]
-#[tokio::test]
-async fn checker_functions_after_snapshot_recovery(delay_batch_insertion: bool) {
+async fn _checker_functions_after_snapshot_recovery(
+    delay_batch_insertion: bool,
+    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
+) {
     let pool = ConnectionPool::test_pool().await;
     let mut storage = pool.access_storage().await.unwrap();
     storage
@@ -499,8 +500,6 @@ async fn checker_functions_after_snapshot_recovery(delay_batch_insertion: bool) 
         .await;
 
     let l1_batch = create_l1_batch_with_metadata(99);
-
-    let l1_batch_commit_data_generator = Arc::new(RollupModeL1BatchCommitDataGenerator {});
 
     let commit_tx_input_data = build_commit_tx_input_data(
         slice::from_ref(&l1_batch),
@@ -557,6 +556,21 @@ async fn checker_functions_after_snapshot_recovery(delay_batch_insertion: bool) 
 
     stop_sender.send_replace(true);
     checker_task.await.unwrap().unwrap();
+}
+
+#[test_casing(2, [false, true])]
+#[tokio::test]
+async fn checker_functions_after_snapshot_recovery(delay_batch_insertion: bool) {
+    _checker_functions_after_snapshot_recovery(
+        delay_batch_insertion,
+        Arc::new(RollupModeL1BatchCommitDataGenerator {}),
+    )
+    .await;
+    _checker_functions_after_snapshot_recovery(
+        delay_batch_insertion,
+        Arc::new(ValidiumModeL1BatchCommitDataGenerator {}),
+    )
+    .await;
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
@@ -9,8 +9,12 @@ use zksync_dal::StorageProcessor;
 use zksync_eth_client::clients::MockEthereum;
 use zksync_l1_contract_interface::i_executor::structures::StoredBatchInfo;
 use zksync_types::{
-    aggregated_operations::AggregatedActionType, commitment::L1BatchWithMetadata,
-    l1_batch_commit_data_generator::RollupModeL1BatchCommitDataGenerator, web3::contract::Options,
+    aggregated_operations::AggregatedActionType,
+    commitment::L1BatchWithMetadata,
+    l1_batch_commit_data_generator::{
+        RollupModeL1BatchCommitDataGenerator, ValidiumModeL1BatchCommitDataGenerator,
+    },
+    web3::contract::Options,
     L2ChainId, ProtocolVersion, ProtocolVersionId, H256,
 };
 
@@ -81,15 +85,15 @@ impl UpdateCheckedBatch for mpsc::UnboundedSender<L1BatchNumber> {
     }
 }
 
-#[test]
-fn build_commit_tx_input_data_is_correct() {
+fn _build_commit_tx_input_data_is_correct(
+    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
+) {
     let contract = zksync_contracts::zksync_contract();
     let commit_function = contract.function("commitBatches").unwrap();
     let batches = vec![
         create_l1_batch_with_metadata(1),
         create_l1_batch_with_metadata(2),
     ];
-    let l1_batch_commit_data_generator = Arc::new(RollupModeL1BatchCommitDataGenerator {});
 
     let commit_tx_input_data =
         build_commit_tx_input_data(&batches, l1_batch_commit_data_generator.clone());
@@ -107,6 +111,12 @@ fn build_commit_tx_input_data_is_correct() {
                 .into_token()
         );
     }
+}
+
+#[test]
+fn build_commit_tx_input_data_is_correct() {
+    _build_commit_tx_input_data_is_correct(Arc::new(RollupModeL1BatchCommitDataGenerator {}));
+    _build_commit_tx_input_data_is_correct(Arc::new(ValidiumModeL1BatchCommitDataGenerator {}));
 }
 
 #[test]

--- a/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
@@ -395,10 +395,9 @@ async fn normal_checker_function(
     .await;
 }
 
-#[test_casing(4, SAVE_ACTION_MAPPERS)]
-#[tokio::test]
-async fn checker_processes_pre_boojum_batches(
+async fn _checker_processes_pre_boojum_batches(
     (mapper_name, save_actions_mapper): (&'static str, SaveActionMapper),
+    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
 ) {
     println!("Using save_actions_mapper={mapper_name}");
 
@@ -423,7 +422,6 @@ async fn checker_processes_pre_boojum_batches(
     let mut commit_tx_hash_by_l1_batch = HashMap::with_capacity(l1_batches.len());
     let client = MockEthereum::default();
 
-    let l1_batch_commit_data_generator = Arc::new(RollupModeL1BatchCommitDataGenerator {});
     for (i, l1_batch) in l1_batches.iter().enumerate() {
         let input_data = build_commit_tx_input_data(
             slice::from_ref(l1_batch),
@@ -471,6 +469,23 @@ async fn checker_processes_pre_boojum_batches(
     // Send the stop signal to the checker and wait for it to stop.
     stop_sender.send_replace(true);
     checker_task.await.unwrap().unwrap();
+}
+
+#[test_casing(4, SAVE_ACTION_MAPPERS)]
+#[tokio::test]
+async fn checker_processes_pre_boojum_batches(
+    (mapper_name, save_actions_mapper): (&'static str, SaveActionMapper),
+) {
+    _checker_processes_pre_boojum_batches(
+        (mapper_name, save_actions_mapper),
+        Arc::new(RollupModeL1BatchCommitDataGenerator {}),
+    )
+    .await;
+    _checker_processes_pre_boojum_batches(
+        (mapper_name, save_actions_mapper),
+        Arc::new(ValidiumModeL1BatchCommitDataGenerator {}),
+    )
+    .await;
 }
 
 #[test_casing(2, [false, true])]

--- a/core/lib/zksync_core/src/consistency_checker/tests/test_helpers.rs
+++ b/core/lib/zksync_core/src/consistency_checker/tests/test_helpers.rs
@@ -1,0 +1,300 @@
+use std::{collections::HashMap, slice};
+
+use tokio::sync::mpsc;
+use zksync_eth_client::clients::MockEthereum;
+use zksync_types::{web3::contract::Options, L2ChainId, ProtocolVersion};
+
+use super::*;
+use crate::genesis::{ensure_genesis_state, GenesisParams};
+
+pub fn build_commit_tx_input_data_is_correct(
+    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
+) {
+    let contract = zksync_contracts::zksync_contract();
+    let commit_function = contract.function("commitBatches").unwrap();
+    let batches = vec![
+        create_l1_batch_with_metadata(1),
+        create_l1_batch_with_metadata(2),
+    ];
+
+    let commit_tx_input_data =
+        build_commit_tx_input_data(&batches, l1_batch_commit_data_generator.clone());
+
+    for batch in &batches {
+        let commit_data = ConsistencyChecker::extract_commit_data(
+            &commit_tx_input_data,
+            commit_function,
+            batch.header.number,
+        )
+        .unwrap();
+        assert_eq!(
+            commit_data,
+            CommitBatchInfo::new(batch, l1_batch_commit_data_generator.clone().clone())
+                .into_token()
+        );
+    }
+}
+
+pub async fn normal_checker_function(
+    batches_per_transaction: usize,
+    (mapper_name, save_actions_mapper): (&'static str, SaveActionMapper),
+    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
+) {
+    println!("Using save_actions_mapper={mapper_name}");
+
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.access_storage().await.unwrap();
+    ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
+        .await
+        .unwrap();
+
+    let l1_batches: Vec<_> = (1..=10).map(create_l1_batch_with_metadata).collect();
+    let mut commit_tx_hash_by_l1_batch = HashMap::with_capacity(l1_batches.len());
+    let client = MockEthereum::default();
+
+    for (i, l1_batches) in l1_batches.chunks(batches_per_transaction).enumerate() {
+        let input_data =
+            build_commit_tx_input_data(l1_batches, l1_batch_commit_data_generator.clone());
+        let signed_tx = client.sign_prepared_tx(
+            input_data.clone(),
+            Options {
+                nonce: Some(i.into()),
+                ..Options::default()
+            },
+        );
+        let signed_tx = signed_tx.unwrap();
+        client.send_raw_tx(signed_tx.raw_tx).await.unwrap();
+        client.execute_tx(signed_tx.hash, true, 1);
+
+        commit_tx_hash_by_l1_batch.extend(
+            l1_batches
+                .iter()
+                .map(|batch| (batch.header.number, signed_tx.hash)),
+        );
+    }
+
+    let (l1_batch_updates_sender, mut l1_batch_updates_receiver) = mpsc::unbounded_channel();
+    let checker = ConsistencyChecker {
+        l1_batch_updater: Box::new(l1_batch_updates_sender),
+        ..create_mock_checker(client, pool.clone())
+    };
+
+    let (stop_sender, stop_receiver) = watch::channel(false);
+    let checker_task =
+        tokio::spawn(checker.run(stop_receiver, l1_batch_commit_data_generator.clone()));
+
+    // Add new batches to the storage.
+    for save_action in save_actions_mapper(&l1_batches) {
+        save_action
+            .apply(&mut storage, &commit_tx_hash_by_l1_batch)
+            .await;
+        tokio::time::sleep(Duration::from_millis(7)).await;
+    }
+
+    // Wait until all batches are checked.
+    loop {
+        let checked_batch = l1_batch_updates_receiver.recv().await.unwrap();
+        if checked_batch == l1_batches.last().unwrap().header.number {
+            break;
+        }
+    }
+
+    // Send the stop signal to the checker and wait for it to stop.
+    stop_sender.send_replace(true);
+    checker_task.await.unwrap().unwrap();
+}
+
+pub async fn checker_processes_pre_boojum_batches(
+    (mapper_name, save_actions_mapper): (&'static str, SaveActionMapper),
+    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
+) {
+    println!("Using save_actions_mapper={mapper_name}");
+
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.access_storage().await.unwrap();
+    let genesis_params = GenesisParams {
+        protocol_version: PRE_BOOJUM_PROTOCOL_VERSION,
+        ..GenesisParams::mock()
+    };
+    ensure_genesis_state(&mut storage, L2ChainId::default(), &genesis_params)
+        .await
+        .unwrap();
+    storage
+        .protocol_versions_dal()
+        .save_protocol_version_with_tx(ProtocolVersion::default())
+        .await;
+
+    let l1_batches: Vec<_> = (1..=5)
+        .map(create_pre_boojum_l1_batch_with_metadata)
+        .chain((6..=10).map(create_l1_batch_with_metadata))
+        .collect();
+    let mut commit_tx_hash_by_l1_batch = HashMap::with_capacity(l1_batches.len());
+    let client = MockEthereum::default();
+
+    for (i, l1_batch) in l1_batches.iter().enumerate() {
+        let input_data = build_commit_tx_input_data(
+            slice::from_ref(l1_batch),
+            l1_batch_commit_data_generator.clone(),
+        );
+        let signed_tx = client.sign_prepared_tx(
+            input_data.clone(),
+            Options {
+                nonce: Some(i.into()),
+                ..Options::default()
+            },
+        );
+        let signed_tx = signed_tx.unwrap();
+        client.send_raw_tx(signed_tx.raw_tx).await.unwrap();
+        client.execute_tx(signed_tx.hash, true, 1);
+
+        commit_tx_hash_by_l1_batch.insert(l1_batch.header.number, signed_tx.hash);
+    }
+
+    let (l1_batch_updates_sender, mut l1_batch_updates_receiver) = mpsc::unbounded_channel();
+    let checker = ConsistencyChecker {
+        l1_batch_updater: Box::new(l1_batch_updates_sender),
+        ..create_mock_checker(client, pool.clone())
+    };
+
+    let (stop_sender, stop_receiver) = watch::channel(false);
+    let checker_task = tokio::spawn(checker.run(stop_receiver, l1_batch_commit_data_generator));
+
+    // Add new batches to the storage.
+    for save_action in save_actions_mapper(&l1_batches) {
+        save_action
+            .apply(&mut storage, &commit_tx_hash_by_l1_batch)
+            .await;
+        tokio::time::sleep(Duration::from_millis(7)).await;
+    }
+
+    // Wait until all batches are checked.
+    loop {
+        let checked_batch = l1_batch_updates_receiver.recv().await.unwrap();
+        if checked_batch == l1_batches.last().unwrap().header.number {
+            break;
+        }
+    }
+
+    // Send the stop signal to the checker and wait for it to stop.
+    stop_sender.send_replace(true);
+    checker_task.await.unwrap().unwrap();
+}
+
+pub async fn checker_functions_after_snapshot_recovery(
+    delay_batch_insertion: bool,
+    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
+) {
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.access_storage().await.unwrap();
+    storage
+        .protocol_versions_dal()
+        .save_protocol_version_with_tx(ProtocolVersion::default())
+        .await;
+
+    let l1_batch = create_l1_batch_with_metadata(99);
+
+    let commit_tx_input_data = build_commit_tx_input_data(
+        slice::from_ref(&l1_batch),
+        l1_batch_commit_data_generator.clone(),
+    );
+    let client = MockEthereum::default();
+    let signed_tx = client.sign_prepared_tx(
+        commit_tx_input_data.clone(),
+        Options {
+            nonce: Some(0.into()),
+            ..Options::default()
+        },
+    );
+    let signed_tx = signed_tx.unwrap();
+    let commit_tx_hash = signed_tx.hash;
+    client.send_raw_tx(signed_tx.raw_tx).await.unwrap();
+    client.execute_tx(commit_tx_hash, true, 1);
+
+    let save_actions = [
+        SaveAction::InsertBatch(&l1_batch),
+        SaveAction::SaveMetadata(&l1_batch),
+        SaveAction::InsertCommitTx(l1_batch.header.number),
+    ];
+    let commit_tx_hash_by_l1_batch = HashMap::from([(l1_batch.header.number, commit_tx_hash)]);
+
+    if !delay_batch_insertion {
+        for &save_action in &save_actions {
+            save_action
+                .apply(&mut storage, &commit_tx_hash_by_l1_batch)
+                .await;
+        }
+    }
+
+    let (l1_batch_updates_sender, mut l1_batch_updates_receiver) = mpsc::unbounded_channel();
+    let checker = ConsistencyChecker {
+        l1_batch_updater: Box::new(l1_batch_updates_sender),
+        ..create_mock_checker(client, pool.clone())
+    };
+    let (stop_sender, stop_receiver) = watch::channel(false);
+    let checker_task = tokio::spawn(checker.run(stop_receiver, l1_batch_commit_data_generator));
+
+    if delay_batch_insertion {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        for &save_action in &save_actions {
+            save_action
+                .apply(&mut storage, &commit_tx_hash_by_l1_batch)
+                .await;
+        }
+    }
+
+    // Wait until the batch is checked.
+    let checked_batch = l1_batch_updates_receiver.recv().await.unwrap();
+    assert_eq!(checked_batch, l1_batch.header.number);
+
+    stop_sender.send_replace(true);
+    checker_task.await.unwrap().unwrap();
+}
+
+pub async fn checker_detects_incorrect_tx_data(
+    kind: IncorrectDataKind,
+    snapshot_recovery: bool,
+    l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
+) {
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.access_storage().await.unwrap();
+    if snapshot_recovery {
+        storage
+            .protocol_versions_dal()
+            .save_protocol_version_with_tx(ProtocolVersion::default())
+            .await;
+    } else {
+        ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
+            .await
+            .unwrap();
+    }
+
+    let l1_batch = create_l1_batch_with_metadata(if snapshot_recovery { 99 } else { 1 });
+    let client = MockEthereum::default();
+    let commit_tx_hash = kind
+        .apply(&client, &l1_batch, l1_batch_commit_data_generator.clone())
+        .await;
+    let commit_tx_hash_by_l1_batch = HashMap::from([(l1_batch.header.number, commit_tx_hash)]);
+
+    let save_actions = [
+        SaveAction::InsertBatch(&l1_batch),
+        SaveAction::SaveMetadata(&l1_batch),
+        SaveAction::InsertCommitTx(l1_batch.header.number),
+    ];
+    for save_action in save_actions {
+        save_action
+            .apply(&mut storage, &commit_tx_hash_by_l1_batch)
+            .await;
+    }
+    drop(storage);
+
+    let checker = create_mock_checker(client, pool);
+    let (_stop_sender, stop_receiver) = watch::channel(false);
+    // The checker must stop with an error.
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        checker.run(stop_receiver, l1_batch_commit_data_generator),
+    )
+    .await
+    .expect("Timed out waiting for checker to stop")
+    .unwrap_err();
+}


### PR DESCRIPTION
# Failing tests
## `build_commit_tx_input_data_is_correct` 
```
assertion `left == right` failed
  left: Tuple([Uint(1), Uint(1), Uint(21), FixedBytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]), Uint(0), FixedBytes([197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229, 0, 182, 83, 202, 130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112]), FixedBytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), FixedBytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), Bytes([]), Bytes([0])])
 right: Tuple([Uint(1), Uint(1), Uint(21), FixedBytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]), Uint(0), FixedBytes([197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229, 0, 182, 83, 202, 130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112]), FixedBytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), FixedBytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), Bytes([])])
```
## `normal_checker_function` `checker_processes_pre_boojum_batches` `checker_functions_after_snapshot_recovery`
```
thread 'consistency_checker::tests::normal_checker_function::case_00' panicked at core/lib/zksync_core/src/consistency_checker/tests/mod.rs:369:68:
called `Option::unwrap()` on a `None` value
```
It fails in this line: 
```rust
let checked_batch = l1_batch_updates_receiver.recv().await.unwrap();
```
# Run the tests 

To run the tests, you can execute the following command:
```sh
zk test rust --package zksync_core --lib -j 1 -- consistency_checker::tests
```

# Fix tests
Failed test errors occur when comparing the result of the contract deployed using the "commitBaches" method with the `ValidiumModeL1BatchCommitDataGenerator`. 

This is solved by adding the following change:

https://github.com/lambdaclass/zksync-era/blob/159225b355caf0622d48a83bdb41e73856753387/core/lib/types/src/l1_batch_commit_data_generator.rs#L25-L29

I believe this change has been commented on at the last validium meeting by @ilitteri .

cc @mationorato @ilitteri 
