### PR TITLE
feat:  Match ABI encoding adding `bytes pubdata` at the end of the encoding in Validium's commit data

### DIFF
--- a/core/lib/types/src/l1_batch_commit_data_generator.rs
+++ b/core/lib/types/src/l1_batch_commit_data_generator.rs
@@ -23,7 +23,9 @@ impl L1BatchCommitDataGenerator for RollupModeL1BatchCommitDataGenerator {
 
 impl L1BatchCommitDataGenerator for ValidiumModeL1BatchCommitDataGenerator {
     fn l1_commit_data(&self, l1_batch_with_metadata: &L1BatchWithMetadata) -> Token {
-        Token::Tuple(validium_mode_l1_commit_data(l1_batch_with_metadata))
+        let mut commit_data = validium_mode_l1_commit_data(l1_batch_with_metadata);
+        commit_data.push(Token::Bytes([0].to_vec()));
+        Token::Tuple(commit_data)
     }
 }
 


### PR DESCRIPTION
As it says in the issue, we need to add this `Bytes([0])` as `pubdata` in the **Validium commit data** to match the ABI encoding.
This is checked in `consistency_checker` tests: this change is required to pass tests in validium mode. You can see more details in [this PR](https://github.com/lambdaclass/zksync-era/pull/121) description.