### PR TITLE
feat: adapt `zksync_env_config::eth_sender` tests for running both in Validium mode and Rollup mode

### DIFF
--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -33,7 +33,7 @@ mod tests {
 
     static MUTEX: EnvMutex = EnvMutex::new();
 
-    fn expected_config() -> ETHSenderConfig {
+    fn rollup_expected_config() -> ETHSenderConfig {
         ETHSenderConfig {
             sender: SenderConfig {
                 aggregated_proof_sizes: vec![1, 5],
@@ -69,8 +69,14 @@ mod tests {
         }
     }
 
+    fn validium_expected_config() -> ETHSenderConfig {
+        let mut validium_config = rollup_expected_config();
+        validium_config.gas_adjuster.l1_gas_per_pubdata_byte = 0;
+        validium_config
+    }
+
     #[test]
-    fn from_env() {
+    fn rollup_from_env() {
         let mut lock = MUTEX.lock();
         let config = r#"
             ETH_SENDER_SENDER_WAIT_CONFIRMATIONS="1"
@@ -104,7 +110,49 @@ mod tests {
         lock.set_env(config);
 
         let actual = ETHSenderConfig::from_env().unwrap();
-        assert_eq!(actual, expected_config());
+        assert_eq!(actual, rollup_expected_config());
+        assert_eq!(
+            actual.sender.private_key().unwrap(),
+            hash("27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be")
+        );
+    }
+
+    #[test]
+    fn validium_from_env() {
+        let mut lock = MUTEX.lock();
+        let config = r#"
+            ETH_SENDER_SENDER_WAIT_CONFIRMATIONS="1"
+            ETH_SENDER_SENDER_TX_POLL_PERIOD="3"
+            ETH_SENDER_SENDER_AGGREGATE_TX_POLL_PERIOD="3"
+            ETH_SENDER_SENDER_MAX_TXS_IN_FLIGHT="3"
+            ETH_SENDER_SENDER_OPERATOR_PRIVATE_KEY="0x27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be"
+            ETH_SENDER_SENDER_PROOF_SENDING_MODE="SkipEveryProof"
+            ETH_SENDER_GAS_ADJUSTER_DEFAULT_PRIORITY_FEE_PER_GAS="20000000000"
+            ETH_SENDER_GAS_ADJUSTER_MAX_BASE_FEE_SAMPLES="10000"
+            ETH_SENDER_GAS_ADJUSTER_PRICING_FORMULA_PARAMETER_A="1.5"
+            ETH_SENDER_GAS_ADJUSTER_PRICING_FORMULA_PARAMETER_B="1.0005"
+            ETH_SENDER_GAS_ADJUSTER_INTERNAL_L1_PRICING_MULTIPLIER="0.8"
+            ETH_SENDER_GAS_ADJUSTER_POLL_PERIOD="15"
+            ETH_SENDER_GAS_ADJUSTER_MAX_L1_GAS_PRICE="100000000"
+            ETH_SENDER_WAIT_FOR_PROOFS="false"
+            ETH_SENDER_SENDER_AGGREGATED_PROOF_SIZES="1,5"
+            ETH_SENDER_SENDER_MAX_AGGREGATED_BLOCKS_TO_COMMIT="3"
+            ETH_SENDER_SENDER_MAX_AGGREGATED_BLOCKS_TO_EXECUTE="4"
+            ETH_SENDER_SENDER_AGGREGATED_BLOCK_COMMIT_DEADLINE="30"
+            ETH_SENDER_SENDER_AGGREGATED_BLOCK_PROVE_DEADLINE="3000"
+            ETH_SENDER_SENDER_AGGREGATED_BLOCK_EXECUTE_DEADLINE="4000"
+            ETH_SENDER_SENDER_TIMESTAMP_CRITERIA_MAX_ALLOWED_LAG="30"
+            ETH_SENDER_SENDER_MAX_AGGREGATED_TX_GAS="4000000"
+            ETH_SENDER_SENDER_MAX_ETH_TX_DATA_SIZE="120000"
+            ETH_SENDER_SENDER_L1_BATCH_MIN_AGE_BEFORE_EXECUTE_SECONDS="1000"
+            ETH_SENDER_SENDER_MAX_ACCEPTABLE_PRIORITY_FEE_IN_GWEI="100000000000"
+            ETH_SENDER_SENDER_PROOF_LOADING_MODE="OldProofFromDb"
+            ETH_SENDER_GAS_ADJUSTER_L1_GAS_PER_PUBDATA_BYTE=0
+            "#;
+        lock.set_env(config);
+
+        let actual = ETHSenderConfig::from_env().unwrap();
+        assert_eq!(actual, validium_expected_config());
         assert_eq!(
             actual.sender.private_key().unwrap(),
             hash("27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be")

--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -75,10 +75,21 @@ mod tests {
         validium_config
     }
 
+    fn from_env(config: &str, expected_config: ETHSenderConfig) {
+        let mut lock = MUTEX.lock();
+        lock.set_env(config);
+
+        let actual = ETHSenderConfig::from_env().unwrap();
+        assert_eq!(actual, expected_config);
+        assert_eq!(
+            actual.sender.private_key().unwrap(),
+            hash("27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be")
+        );
+    }
+
     #[test]
     fn rollup_from_env() {
-        let mut lock = MUTEX.lock();
-        let config = r#"
+        let rollup_config = r#"
             ETH_SENDER_SENDER_WAIT_CONFIRMATIONS="1"
             ETH_SENDER_SENDER_TX_POLL_PERIOD="3"
             ETH_SENDER_SENDER_AGGREGATE_TX_POLL_PERIOD="3"
@@ -107,20 +118,12 @@ mod tests {
             ETH_SENDER_SENDER_PROOF_LOADING_MODE="OldProofFromDb"
             ETH_SENDER_GAS_ADJUSTER_L1_GAS_PER_PUBDATA_BYTE=17
             "#;
-        lock.set_env(config);
-
-        let actual = ETHSenderConfig::from_env().unwrap();
-        assert_eq!(actual, rollup_expected_config());
-        assert_eq!(
-            actual.sender.private_key().unwrap(),
-            hash("27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be")
-        );
+        from_env(rollup_config, rollup_expected_config())
     }
 
     #[test]
     fn validium_from_env() {
-        let mut lock = MUTEX.lock();
-        let config = r#"
+        let validium_config = r#"
             ETH_SENDER_SENDER_WAIT_CONFIRMATIONS="1"
             ETH_SENDER_SENDER_TX_POLL_PERIOD="3"
             ETH_SENDER_SENDER_AGGREGATE_TX_POLL_PERIOD="3"
@@ -149,13 +152,6 @@ mod tests {
             ETH_SENDER_SENDER_PROOF_LOADING_MODE="OldProofFromDb"
             ETH_SENDER_GAS_ADJUSTER_L1_GAS_PER_PUBDATA_BYTE=0
             "#;
-        lock.set_env(config);
-
-        let actual = ETHSenderConfig::from_env().unwrap();
-        assert_eq!(actual, validium_expected_config());
-        assert_eq!(
-            actual.sender.private_key().unwrap(),
-            hash("27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be")
-        );
+        from_env(validium_config, validium_expected_config());
     }
 }


### PR DESCRIPTION
Closes #134 

### Changes Made
This pull request introduces enhancements to the existing test suite for the ETHSenderConfig in the env_config crate. The primary goal is to create dedicated configurations for Rollup and Validium scenarios and provide specific tests for each.

### Key Modifications
New Test Configurations:

- Two new functions, rollup_expected_config and validium_expected_config, have been added to generate configurations tailored for Rollup and Validium use cases.
- Additional Test Methods: Two new test methods, rollup_from_env and validium_from_env, have been implemented to specifically test Rollup and Validium configurations, respectively.
- Validium Configuration Adjustment: The validium_expected_config function now sets the l1_gas_per_pubdata_byte field to 0 for Validium, reflecting the required Validium configuration.

### How to test

`zk test rust --package zksync_env_config --lib -j 1 -- eth_sender::tests`