### PR TITLE
feat: adapt `zksync_env_config::chain` tests for running both in Validium mode and Rollup mode

### DIFF
--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -100,10 +100,34 @@ mod tests {
         }
     }
 
+    fn state_keeper_config(config_mock: &str, mode: L1BatchCommitDataGeneratorMode) {
+        let mut lock = MUTEX.lock();
+        lock.set_env(config_mock);
+        let current_config = StateKeeperConfig::from_env().unwrap();
+        assert_eq!(current_config, expected_state_keeper_config(mode));
+    }
+
+    fn state_keeper_from_env_rollup(config_mock: &str) {
+        let config_mock_rollup = format!(
+            "{}\nCHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Rollup",
+            config_mock
+        );
+        state_keeper_config(&config_mock_rollup, L1BatchCommitDataGeneratorMode::Rollup);
+    }
+
+    fn state_keeper_from_env_validium(config_mock: &str) {
+        let config_mock_validium = format!(
+            "{}\nCHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Validium",
+            config_mock
+        );
+        state_keeper_config(
+            &config_mock_validium,
+            L1BatchCommitDataGeneratorMode::Validium,
+        );
+    }
+
     #[test]
     fn state_keeper_from_env() {
-        let mut lock = MUTEX.lock();
-
         let config_mock = r#"
             CHAIN_STATE_KEEPER_TRANSACTION_SLOTS="50"
             CHAIN_STATE_KEEPER_FEE_ACCOUNT_ADDR="0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7"
@@ -130,30 +154,8 @@ mod tests {
             CHAIN_STATE_KEEPER_UPLOAD_WITNESS_INPUTS_TO_GCS="false"
             CHAIN_STATE_KEEPER_ENUM_INDEX_MIGRATION_CHUNK_SIZE="2000"
         "#;
-
-        // Test Rollup Configuration
-        let config_mock_rollup = format!(
-            "{}\nCHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Rollup",
-            config_mock
-        );
-        lock.set_env(&config_mock_rollup);
-        let current_config_rollup = StateKeeperConfig::from_env().unwrap();
-        assert_eq!(
-            current_config_rollup,
-            expected_state_keeper_config(L1BatchCommitDataGeneratorMode::Rollup)
-        );
-
-        // Test Validium Configuration
-        let config_mock_validium = format!(
-            "{}\nCHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Validium",
-            config_mock
-        );
-        lock.set_env(&config_mock_validium);
-        let current_config_validium = StateKeeperConfig::from_env().unwrap();
-        assert_eq!(
-            current_config_validium,
-            expected_state_keeper_config(L1BatchCommitDataGeneratorMode::Validium)
-        );
+        state_keeper_from_env_rollup(config_mock);
+        state_keeper_from_env_validium(config_mock);
     }
 
     fn expected_operations_manager_config() -> OperationsManagerConfig {

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -43,6 +43,8 @@ mod tests {
     use crate::test_utils::{addr, EnvMutex};
 
     static MUTEX: EnvMutex = EnvMutex::new();
+    const VALIDIUM_L1_BATCH_COMMIT_DATA_GENERATOR_MODE: &str = "Validium";
+    const ROLLUP_L1_BATCH_COMMIT_DATA_GENERATOR_MODE: &str = "Rollup";
 
     fn expected_network_config() -> NetworkConfig {
         NetworkConfig {
@@ -100,35 +102,9 @@ mod tests {
         }
     }
 
-    fn state_keeper_config(config_mock: &str, mode: L1BatchCommitDataGeneratorMode) {
-        let mut lock = MUTEX.lock();
-        lock.set_env(config_mock);
-        let current_config = StateKeeperConfig::from_env().unwrap();
-        assert_eq!(current_config, expected_state_keeper_config(mode));
-    }
-
-    fn state_keeper_from_env_rollup(config_mock: &str) {
-        let config_mock_rollup = format!(
-            "{}\nCHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Rollup",
-            config_mock
-        );
-        state_keeper_config(&config_mock_rollup, L1BatchCommitDataGeneratorMode::Rollup);
-    }
-
-    fn state_keeper_from_env_validium(config_mock: &str) {
-        let config_mock_validium = format!(
-            "{}\nCHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Validium",
-            config_mock
-        );
-        state_keeper_config(
-            &config_mock_validium,
-            L1BatchCommitDataGeneratorMode::Validium,
-        );
-    }
-
-    #[test]
-    fn state_keeper_from_env() {
-        let config_mock = r#"
+    fn state_keeper_config(l1_batch_commit_data_generator_mode: &str) -> String {
+        format!(
+            r#"
             CHAIN_STATE_KEEPER_TRANSACTION_SLOTS="50"
             CHAIN_STATE_KEEPER_FEE_ACCOUNT_ADDR="0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7"
             CHAIN_STATE_KEEPER_MAX_SINGLE_TX_GAS="1000000"
@@ -153,27 +129,29 @@ mod tests {
             CHAIN_STATE_KEEPER_SAVE_CALL_TRACES="false"
             CHAIN_STATE_KEEPER_UPLOAD_WITNESS_INPUTS_TO_GCS="false"
             CHAIN_STATE_KEEPER_ENUM_INDEX_MIGRATION_CHUNK_SIZE="2000"
-        "#;
-        state_keeper_from_env_rollup(config_mock);
-        state_keeper_from_env_validium(config_mock);
+            CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE="{l1_batch_commit_data_generator_mode}"
+        "#
+        )
     }
 
-    fn expected_operations_manager_config() -> OperationsManagerConfig {
-        OperationsManagerConfig {
-            delay_interval: 100,
-        }
+    fn _state_keeper_from_env(config: &str, expected_config: StateKeeperConfig) {
+        let mut lock = MUTEX.lock();
+        lock.set_env(&config);
+
+        let actual = StateKeeperConfig::from_env().unwrap();
+        assert_eq!(actual, expected_config);
     }
 
     #[test]
-    fn operations_manager_from_env() {
-        let mut lock = MUTEX.lock();
-        let config = r#"
-            CHAIN_OPERATIONS_MANAGER_DELAY_INTERVAL="100"
-        "#;
-        lock.set_env(config);
-
-        let actual = OperationsManagerConfig::from_env().unwrap();
-        assert_eq!(actual, expected_operations_manager_config());
+    fn state_keeper_from_env() {
+        _state_keeper_from_env(
+            &state_keeper_config(ROLLUP_L1_BATCH_COMMIT_DATA_GENERATOR_MODE),
+            expected_state_keeper_config(L1BatchCommitDataGeneratorMode::Rollup),
+        );
+        _state_keeper_from_env(
+            &state_keeper_config(VALIDIUM_L1_BATCH_COMMIT_DATA_GENERATOR_MODE),
+            expected_state_keeper_config(L1BatchCommitDataGeneratorMode::Validium),
+        );
     }
 
     fn expected_mempool_config() -> MempoolConfig {

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -198,7 +198,10 @@ mod tests {
         // Test Validium Configuration
         lock.set_env(config_validium);
         let current_config_validium = StateKeeperConfig::from_env().unwrap();
-        assert_eq!(current_config_validium, expected_state_keeper_config_validium());
+        assert_eq!(
+            current_config_validium,
+            expected_state_keeper_config_validium()
+        );
     }
 
     fn expected_operations_manager_config() -> OperationsManagerConfig {

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -192,13 +192,13 @@ mod tests {
         // Test Rollup Configuration
         lock.set_env(config_rollup);
 
-        let actual = StateKeeperConfig::from_env().unwrap();
-        assert_eq!(actual, expected_state_keeper_config_rollup());
+        let current_config_rollup = StateKeeperConfig::from_env().unwrap();
+        assert_eq!(current_config_rollup, expected_state_keeper_config_rollup());
 
         // Test Validium Configuration
         lock.set_env(config_validium);
-        let actual = StateKeeperConfig::from_env().unwrap();
-        assert_eq!(actual, expected_state_keeper_config_validium());
+        let current_config_validium = StateKeeperConfig::from_env().unwrap();
+        assert_eq!(current_config_validium, expected_state_keeper_config_validium());
     }
 
     fn expected_operations_manager_config() -> OperationsManagerConfig {

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -66,7 +66,7 @@ mod tests {
         assert_eq!(actual, expected_network_config());
     }
 
-    fn expected_state_keeper_config() -> StateKeeperConfig {
+    fn expected_state_keeper_config_rollup() -> StateKeeperConfig {
         StateKeeperConfig {
             transaction_slots: 50,
             block_commit_deadline_ms: 2500,
@@ -98,10 +98,42 @@ mod tests {
         }
     }
 
+    fn expected_state_keeper_config_validium() -> StateKeeperConfig {
+        StateKeeperConfig {
+            transaction_slots: 50,
+            block_commit_deadline_ms: 2500,
+            miniblock_commit_deadline_ms: 1000,
+            miniblock_seal_queue_capacity: 10,
+            max_single_tx_gas: 1_000_000,
+            max_allowed_l2_tx_gas_limit: 2_000_000_000,
+            close_block_at_eth_params_percentage: 0.2,
+            close_block_at_gas_percentage: 0.8,
+            close_block_at_geometry_percentage: 0.5,
+            reject_tx_at_eth_params_percentage: 0.8,
+            reject_tx_at_geometry_percentage: 0.3,
+            fee_account_addr: addr("de03a0B5963f75f1C8485B355fF6D30f3093BDE7"),
+            reject_tx_at_gas_percentage: 0.5,
+            minimal_l2_gas_price: 100000000,
+            compute_overhead_part: 0.0,
+            pubdata_overhead_part: 1.0,
+            batch_overhead_l1_gas: 800_000,
+            max_gas_per_batch: 200_000_000,
+            max_pubdata_per_batch: 100_000,
+            fee_model_version: FeeModelVersion::V2,
+            validation_computational_gas_limit: 10_000_000,
+            save_call_traces: false,
+            virtual_blocks_interval: 1,
+            virtual_blocks_per_miniblock: 1,
+            upload_witness_inputs_to_gcs: false,
+            enum_index_migration_chunk_size: Some(2_000),
+            l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode::Validium,
+        }
+    }
+
     #[test]
     fn state_keeper_from_env() {
         let mut lock = MUTEX.lock();
-        let config = r#"
+        let config_rollup = r#"
             CHAIN_STATE_KEEPER_TRANSACTION_SLOTS="50"
             CHAIN_STATE_KEEPER_FEE_ACCOUNT_ADDR="0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7"
             CHAIN_STATE_KEEPER_MAX_SINGLE_TX_GAS="1000000"
@@ -128,10 +160,45 @@ mod tests {
             CHAIN_STATE_KEEPER_ENUM_INDEX_MIGRATION_CHUNK_SIZE="2000"
             CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Rollup
         "#;
-        lock.set_env(config);
+
+        let config_validium = r#"
+            CHAIN_STATE_KEEPER_TRANSACTION_SLOTS="50"
+            CHAIN_STATE_KEEPER_FEE_ACCOUNT_ADDR="0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7"
+            CHAIN_STATE_KEEPER_MAX_SINGLE_TX_GAS="1000000"
+            CHAIN_STATE_KEEPER_MAX_ALLOWED_L2_TX_GAS_LIMIT="2000000000"
+            CHAIN_STATE_KEEPER_CLOSE_BLOCK_AT_GEOMETRY_PERCENTAGE="0.5"
+            CHAIN_STATE_KEEPER_CLOSE_BLOCK_AT_GAS_PERCENTAGE="0.8"
+            CHAIN_STATE_KEEPER_CLOSE_BLOCK_AT_ETH_PARAMS_PERCENTAGE="0.2"
+            CHAIN_STATE_KEEPER_REJECT_TX_AT_GEOMETRY_PERCENTAGE="0.3"
+            CHAIN_STATE_KEEPER_REJECT_TX_AT_ETH_PARAMS_PERCENTAGE="0.8"
+            CHAIN_STATE_KEEPER_REJECT_TX_AT_GAS_PERCENTAGE="0.5"
+            CHAIN_STATE_KEEPER_BLOCK_COMMIT_DEADLINE_MS="2500"
+            CHAIN_STATE_KEEPER_MINIBLOCK_COMMIT_DEADLINE_MS="1000"
+            CHAIN_STATE_KEEPER_MINIBLOCK_SEAL_QUEUE_CAPACITY="10"
+            CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE="100000000"
+            CHAIN_STATE_KEEPER_COMPUTE_OVERHEAD_PART="0.0"
+            CHAIN_STATE_KEEPER_PUBDATA_OVERHEAD_PART="1.0"
+            CHAIN_STATE_KEEPER_BATCH_OVERHEAD_L1_GAS="800000"
+            CHAIN_STATE_KEEPER_MAX_GAS_PER_BATCH="200000000"
+            CHAIN_STATE_KEEPER_MAX_PUBDATA_PER_BATCH="100000"
+            CHAIN_STATE_KEEPER_FEE_MODEL_VERSION="V2"
+            CHAIN_STATE_KEEPER_VALIDATION_COMPUTATIONAL_GAS_LIMIT="10000000"
+            CHAIN_STATE_KEEPER_SAVE_CALL_TRACES="false"
+            CHAIN_STATE_KEEPER_UPLOAD_WITNESS_INPUTS_TO_GCS="false"
+            CHAIN_STATE_KEEPER_ENUM_INDEX_MIGRATION_CHUNK_SIZE="2000"
+            CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Validium
+        "#;
+
+        // Test Rollup Configuration
+        lock.set_env(config_rollup);
 
         let actual = StateKeeperConfig::from_env().unwrap();
-        assert_eq!(actual, expected_state_keeper_config());
+        assert_eq!(actual, expected_state_keeper_config_rollup());
+
+        // Test Validium Configuration
+        lock.set_env(config_validium);
+        let actual = StateKeeperConfig::from_env().unwrap();
+        assert_eq!(actual, expected_state_keeper_config_validium());
     }
 
     fn expected_operations_manager_config() -> OperationsManagerConfig {

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -66,7 +66,9 @@ mod tests {
         assert_eq!(actual, expected_network_config());
     }
 
-    fn expected_state_keeper_config_rollup() -> StateKeeperConfig {
+    fn expected_state_keeper_config(
+        l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode,
+    ) -> StateKeeperConfig {
         StateKeeperConfig {
             transaction_slots: 50,
             block_commit_deadline_ms: 2500,
@@ -94,39 +96,7 @@ mod tests {
             virtual_blocks_per_miniblock: 1,
             upload_witness_inputs_to_gcs: false,
             enum_index_migration_chunk_size: Some(2_000),
-            l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode::Rollup,
-        }
-    }
-
-    fn expected_state_keeper_config_validium() -> StateKeeperConfig {
-        StateKeeperConfig {
-            transaction_slots: 50,
-            block_commit_deadline_ms: 2500,
-            miniblock_commit_deadline_ms: 1000,
-            miniblock_seal_queue_capacity: 10,
-            max_single_tx_gas: 1_000_000,
-            max_allowed_l2_tx_gas_limit: 2_000_000_000,
-            close_block_at_eth_params_percentage: 0.2,
-            close_block_at_gas_percentage: 0.8,
-            close_block_at_geometry_percentage: 0.5,
-            reject_tx_at_eth_params_percentage: 0.8,
-            reject_tx_at_geometry_percentage: 0.3,
-            fee_account_addr: addr("de03a0B5963f75f1C8485B355fF6D30f3093BDE7"),
-            reject_tx_at_gas_percentage: 0.5,
-            minimal_l2_gas_price: 100000000,
-            compute_overhead_part: 0.0,
-            pubdata_overhead_part: 1.0,
-            batch_overhead_l1_gas: 800_000,
-            max_gas_per_batch: 200_000_000,
-            max_pubdata_per_batch: 100_000,
-            fee_model_version: FeeModelVersion::V2,
-            validation_computational_gas_limit: 10_000_000,
-            save_call_traces: false,
-            virtual_blocks_interval: 1,
-            virtual_blocks_per_miniblock: 1,
-            upload_witness_inputs_to_gcs: false,
-            enum_index_migration_chunk_size: Some(2_000),
-            l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode::Validium,
+            l1_batch_commit_data_generator_mode,
         }
     }
 
@@ -168,7 +138,10 @@ mod tests {
         );
         lock.set_env(&config_mock_rollup);
         let current_config_rollup = StateKeeperConfig::from_env().unwrap();
-        assert_eq!(current_config_rollup, expected_state_keeper_config_rollup());
+        assert_eq!(
+            current_config_rollup,
+            expected_state_keeper_config(L1BatchCommitDataGeneratorMode::Rollup)
+        );
 
         // Test Validium Configuration
         let config_mock_validium = format!(
@@ -179,7 +152,7 @@ mod tests {
         let current_config_validium = StateKeeperConfig::from_env().unwrap();
         assert_eq!(
             current_config_validium,
-            expected_state_keeper_config_validium()
+            expected_state_keeper_config(L1BatchCommitDataGeneratorMode::Validium)
         );
     }
 

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -136,7 +136,7 @@ mod tests {
 
     fn _state_keeper_from_env(config: &str, expected_config: StateKeeperConfig) {
         let mut lock = MUTEX.lock();
-        lock.set_env(&config);
+        lock.set_env(config);
 
         let actual = StateKeeperConfig::from_env().unwrap();
         assert_eq!(actual, expected_config);

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -133,35 +133,8 @@ mod tests {
     #[test]
     fn state_keeper_from_env() {
         let mut lock = MUTEX.lock();
-        let config_rollup = r#"
-            CHAIN_STATE_KEEPER_TRANSACTION_SLOTS="50"
-            CHAIN_STATE_KEEPER_FEE_ACCOUNT_ADDR="0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7"
-            CHAIN_STATE_KEEPER_MAX_SINGLE_TX_GAS="1000000"
-            CHAIN_STATE_KEEPER_MAX_ALLOWED_L2_TX_GAS_LIMIT="2000000000"
-            CHAIN_STATE_KEEPER_CLOSE_BLOCK_AT_GEOMETRY_PERCENTAGE="0.5"
-            CHAIN_STATE_KEEPER_CLOSE_BLOCK_AT_GAS_PERCENTAGE="0.8"
-            CHAIN_STATE_KEEPER_CLOSE_BLOCK_AT_ETH_PARAMS_PERCENTAGE="0.2"
-            CHAIN_STATE_KEEPER_REJECT_TX_AT_GEOMETRY_PERCENTAGE="0.3"
-            CHAIN_STATE_KEEPER_REJECT_TX_AT_ETH_PARAMS_PERCENTAGE="0.8"
-            CHAIN_STATE_KEEPER_REJECT_TX_AT_GAS_PERCENTAGE="0.5"
-            CHAIN_STATE_KEEPER_BLOCK_COMMIT_DEADLINE_MS="2500"
-            CHAIN_STATE_KEEPER_MINIBLOCK_COMMIT_DEADLINE_MS="1000"
-            CHAIN_STATE_KEEPER_MINIBLOCK_SEAL_QUEUE_CAPACITY="10"
-            CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE="100000000"
-            CHAIN_STATE_KEEPER_COMPUTE_OVERHEAD_PART="0.0"
-            CHAIN_STATE_KEEPER_PUBDATA_OVERHEAD_PART="1.0"
-            CHAIN_STATE_KEEPER_BATCH_OVERHEAD_L1_GAS="800000"
-            CHAIN_STATE_KEEPER_MAX_GAS_PER_BATCH="200000000"
-            CHAIN_STATE_KEEPER_MAX_PUBDATA_PER_BATCH="100000"
-            CHAIN_STATE_KEEPER_FEE_MODEL_VERSION="V2"
-            CHAIN_STATE_KEEPER_VALIDATION_COMPUTATIONAL_GAS_LIMIT="10000000"
-            CHAIN_STATE_KEEPER_SAVE_CALL_TRACES="false"
-            CHAIN_STATE_KEEPER_UPLOAD_WITNESS_INPUTS_TO_GCS="false"
-            CHAIN_STATE_KEEPER_ENUM_INDEX_MIGRATION_CHUNK_SIZE="2000"
-            CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Rollup
-        "#;
 
-        let config_validium = r#"
+        let config_mock = r#"
             CHAIN_STATE_KEEPER_TRANSACTION_SLOTS="50"
             CHAIN_STATE_KEEPER_FEE_ACCOUNT_ADDR="0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7"
             CHAIN_STATE_KEEPER_MAX_SINGLE_TX_GAS="1000000"
@@ -186,17 +159,23 @@ mod tests {
             CHAIN_STATE_KEEPER_SAVE_CALL_TRACES="false"
             CHAIN_STATE_KEEPER_UPLOAD_WITNESS_INPUTS_TO_GCS="false"
             CHAIN_STATE_KEEPER_ENUM_INDEX_MIGRATION_CHUNK_SIZE="2000"
-            CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Validium
         "#;
 
         // Test Rollup Configuration
-        lock.set_env(config_rollup);
-
+        let config_mock_rollup = format!(
+            "{}\nCHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Rollup",
+            config_mock
+        );
+        lock.set_env(&config_mock_rollup);
         let current_config_rollup = StateKeeperConfig::from_env().unwrap();
         assert_eq!(current_config_rollup, expected_state_keeper_config_rollup());
 
         // Test Validium Configuration
-        lock.set_env(config_validium);
+        let config_mock_validium = format!(
+            "{}\nCHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE=Validium",
+            config_mock
+        );
+        lock.set_env(&config_mock_validium);
         let current_config_validium = StateKeeperConfig::from_env().unwrap();
         assert_eq!(
             current_config_validium,


### PR DESCRIPTION
## What ❔

Update the `zksync_env_config::chain` test of `state_keeper_from_env` to take into account the Rollup and Validium mode settings and check that both settings are modified correctly.

## Checklist

- [x] Adapt state keeper config for validium.
- [x] Update the mock configuration for validium.

## Changes

I have separated the `expected_state_keeper_config()` into two functions to manage the `StateKeeperConfig` for both modes and updated `state_keeper_from_env()` test to compare the new mockup configuration and the `StateKeeperConfig` of the Validium mode.

## Check `zksync_env_config::chain` tests

```
zk test rust --package zksync_env_config --lib -j 1 -- chain::tests
```
