### PR TITLE
feat: making `l1_batch_commit_data_generator_mode` a non-mandatory attribute

### DIFF
--- a/core/lib/config/src/configs/chain.rs
+++ b/core/lib/config/src/configs/chain.rs
@@ -52,6 +52,10 @@ pub enum L1BatchCommitDataGeneratorMode {
     Validium,
 }
 
+fn default_l1_batch_commit_data_generator_mode() -> L1BatchCommitDataGeneratorMode {
+    L1BatchCommitDataGeneratorMode::Rollup
+}
+
 #[derive(Debug, Deserialize, Clone, PartialEq, Default)]
 pub struct StateKeeperConfig {
     /// The max number of slots for txs in a block before it should be sealed by the slots sealer.
@@ -123,7 +127,7 @@ pub struct StateKeeperConfig {
 
     /// Number of keys that is processed by enum_index migration in State Keeper each L1 batch.
     pub enum_index_migration_chunk_size: Option<usize>,
-
+    #[serde(default = "default_l1_batch_commit_data_generator_mode")]
     pub l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode,
 }
 


### PR DESCRIPTION
## Description

This pull request addresses the issue regarding the `l1_batch_commit_data_generator_mode` field in the `StateKeeperConfig` struct. The issue stems from the absence of an explicit default value and the lack of `Option` marking, potentially causing the node to enter a crash loop if deployed to an existing environment without prior configuration updates.

Resolves #168.

## Proposed Solution

To resolve this issue, the following changes have been implemented:

1. **Using `serde` with Default Value:** The `serde` attribute has been applied to the `L1BatchCommitDataGeneratorMode` enum, setting `Rollup` as the default value. This ensures that if the field is not explicitly provided in the configuration, `Rollup` will be used by default.

2. **Backward Compatibility:** The solution is designed to be backward-compatible, ensuring a smooth transition for existing environments. This is achieved by providing a default value and utilizing `serde` for serialization and deserialization.

## Changes Made

- Added `#[serde(default)]` attribute to the `Rollup` variant of `L1BatchCommitDataGeneratorMode`.
- Implemented a function, `default_l1_batch_commit_data_generator_mode()`, to provide the default value for the field in case it's not specified in the configuration.
- Updated the `StateKeeperConfig` struct to utilize `serde` with the default value attribute.

## Testing

[TODO]

## Impact

This PR aims to resolve the issue while maintaining backward compatibility. It ensures that the `l1_batch_commit_data_generator_mode` field is properly handled, preventing potential crash loops in existing environments.

