### PR TITLE
feat: Validium update contracts submodule commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "contracts"]
 path = contracts
 url = https://github.com/LambdaClass/era-contracts.git
-branch = feat_validium_mode
+branch = feat_get_rid_of_solpp_need

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "contracts"]
 path = contracts
 url = https://github.com/LambdaClass/era-contracts.git
-branch = update_validium_mode_contracts
+branch = feat_validium_mode


### PR DESCRIPTION
This points now to this PR: https://github.com/lambdaclass/era-contracts/pull/20 but after it is merged, we need to point to https://github.com/matter-labs/era-contracts/pull/216