### PR TITLE
feat: add panic if commitment mode differs

### DIFF
--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -7,8 +7,8 @@ use zksync_types::web3::{
     ethabi,
     transports::Http,
     types::{
-        Address, Block, BlockId, BlockNumber, Bytes, Filter, Log, Transaction, TransactionId,
-        TransactionReceipt, H256, U256, U64,
+        Address, Block, BlockId, BlockNumber, Bytes, CallRequest, Filter, Log, Transaction,
+        TransactionId, TransactionReceipt, H256, U256, U64,
     },
     Web3,
 };
@@ -39,6 +39,10 @@ impl QueryClient {
     pub fn new(node_url: &str) -> Result<Self, Error> {
         let transport = Http::new(node_url)?;
         Ok(transport.into())
+    }
+
+    pub async fn call(&self, params: CallRequest) -> Result<zksync_types::Bytes, web3::Error> {
+        self.web3.eth().call(params, None).await
     }
 }
 

--- a/core/lib/eth_client/src/clients/http/signing.rs
+++ b/core/lib/eth_client/src/clients/http/signing.rs
@@ -11,8 +11,8 @@ use zksync_types::{
         ethabi,
         transports::Http,
         types::{
-            Address, Block, BlockId, BlockNumber, Filter, Log, Transaction, TransactionReceipt,
-            H160, H256, U256, U64,
+            Address, Block, BlockId, BlockNumber, CallRequest, Filter, Log, Transaction,
+            TransactionReceipt, H160, H256, U256, U64,
         },
     },
     L1ChainId, PackedEthSignature, EIP_1559_TX_TYPE,
@@ -94,6 +94,15 @@ impl<S: EthereumSigner> fmt::Debug for SigningClient<S> {
             .field("contract_addr", &self.inner.contract_addr)
             .field("chain_id", &self.inner.chain_id)
             .finish()
+    }
+}
+
+impl<S> SigningClient<S>
+where
+    S: EthereumSigner,
+{
+    pub async fn call(&self, params: CallRequest) -> Result<zksync_types::Bytes, web3::Error> {
+        self.query_client.call(params).await
     }
 }
 


### PR DESCRIPTION
Closes #164 

## What ❔

Adds a cross check of the commitment mode with L1 when setting up the server.

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
