### PR TITLE
feat: adapt `protobuf_config` tests for running both in Validium mode and Rollup mode

### DIFF
--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -286,7 +286,6 @@ impl RandomConfig for configs::chain::StateKeeperConfig {
             virtual_blocks_per_miniblock: g.gen(),
             upload_witness_inputs_to_gcs: g.gen(),
             enum_index_migration_chunk_size: g.gen(),
-            // TODO: this should depend on the mode (Validium or Rollup), but the tests are not adapted yet for this.
             l1_batch_commit_data_generator_mode: g.gen(),
         }
     }
@@ -497,8 +496,7 @@ impl RandomConfig for configs::eth_sender::GasAdjusterConfig {
             internal_enforced_l1_gas_price: g.gen(),
             poll_period: g.gen(),
             max_l1_gas_price: g.gen(),
-            // TODO: this should depend on the mode (Validium or Rollup), but the tests are not adapted yet for this.
-            l1_gas_per_pubdata_byte: g.gen(),
+            l1_gas_per_pubdata_byte: 17,
         }
     }
 }

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -287,8 +287,7 @@ impl RandomConfig for configs::chain::StateKeeperConfig {
             upload_witness_inputs_to_gcs: g.gen(),
             enum_index_migration_chunk_size: g.gen(),
             // TODO: this should depend on the mode (Validium or Rollup), but the tests are not adapted yet for this.
-            l1_batch_commit_data_generator_mode:
-                configs::chain::L1BatchCommitDataGeneratorMode::Rollup,
+            l1_batch_commit_data_generator_mode: g.gen(),
         }
     }
 }
@@ -499,7 +498,7 @@ impl RandomConfig for configs::eth_sender::GasAdjusterConfig {
             poll_period: g.gen(),
             max_l1_gas_price: g.gen(),
             // TODO: this should depend on the mode (Validium or Rollup), but the tests are not adapted yet for this.
-            l1_gas_per_pubdata_byte: 17,
+            l1_gas_per_pubdata_byte: g.gen(),
         }
     }
 }

--- a/core/lib/protobuf_config/src/chain.rs
+++ b/core/lib/protobuf_config/src/chain.rs
@@ -161,7 +161,6 @@ impl ProtoRepr for proto::StateKeeper {
             l1_batch_commit_data_generator_mode: required(
                 &self.l1_batch_commit_data_generator_mode,
             )
-            // TODO: this should depend on the mode (Validium or Rollup), but the tests are not adapted yet for this.
             .and_then(|x| Ok(proto::L1BatchCommitDataGeneratorMode::try_from(*x)?))
             .context("l1_batch_commit_data_generator_mode")?
             .parse(),
@@ -201,7 +200,6 @@ impl ProtoRepr for proto::StateKeeper {
                 .enum_index_migration_chunk_size
                 .as_ref()
                 .map(|x| (*x).try_into().unwrap()),
-            // TODO: this should depend on the mode (Validium or Rollup), but the tests are not adapted yet for this.
             l1_batch_commit_data_generator_mode: Some(
                 proto::L1BatchCommitDataGeneratorMode::new(
                     &this.l1_batch_commit_data_generator_mode,

--- a/core/lib/protobuf_config/src/chain.rs
+++ b/core/lib/protobuf_config/src/chain.rs
@@ -158,11 +158,13 @@ impl ProtoRepr for proto::StateKeeper {
                 .map(|x| x.try_into())
                 .transpose()
                 .context("enum_index_migration_chunk_size")?,
-            l1_batch_commit_data_generator_mode: required(&self.fee_model_version)
-                // TODO: this should depend on the mode (Validium or Rollup), but the tests are not adapted yet for this.
-                .map(|_x| proto::L1BatchCommitDataGeneratorMode::Rollup)
-                .context("l1_batch_commit_data_generator_mode")?
-                .parse(),
+            l1_batch_commit_data_generator_mode: required(
+                &self.l1_batch_commit_data_generator_mode,
+            )
+            // TODO: this should depend on the mode (Validium or Rollup), but the tests are not adapted yet for this.
+            .and_then(|x| Ok(proto::L1BatchCommitDataGeneratorMode::try_from(*x)?))
+            .context("l1_batch_commit_data_generator_mode")?
+            .parse(),
         })
     }
 
@@ -202,7 +204,7 @@ impl ProtoRepr for proto::StateKeeper {
             // TODO: this should depend on the mode (Validium or Rollup), but the tests are not adapted yet for this.
             l1_batch_commit_data_generator_mode: Some(
                 proto::L1BatchCommitDataGeneratorMode::new(
-                    &configs::chain::L1BatchCommitDataGeneratorMode::Rollup,
+                    &this.l1_batch_commit_data_generator_mode,
                 )
                 .into(),
             ),

--- a/core/lib/protobuf_config/src/tests.rs
+++ b/core/lib/protobuf_config/src/tests.rs
@@ -1,8 +1,9 @@
 use pretty_assertions::assert_eq;
 use rand::Rng;
+use testonly::{Gen, RandomConfig};
 use zksync_config::testonly;
 
-use crate::{proto, repr::ProtoRepr};
+use crate::{proto, proto::FeeModelVersion::V1, repr::ProtoRepr};
 
 fn encode<P: ProtoRepr>(msg: &P::Type) -> Vec<u8> {
     let msg = P::build(msg);
@@ -89,4 +90,83 @@ fn test_encoding() {
     encode_decode::<proto::ProofDataHandler>(rng);
     encode_decode::<proto::SnapshotsCreator>(rng);
     encode_decode::<proto::WitnessGenerator>(rng);
+}
+
+#[test]
+fn test_encoding_state_keeper_mode() {
+    // Test Rollup mode
+    let mode_rollup = proto::L1BatchCommitDataGeneratorMode::Rollup;
+    encode_decode_mode::<proto::StateKeeper>(&mode_rollup);
+
+    // Test Validium mode
+    let mode_validium = proto::L1BatchCommitDataGeneratorMode::Validium;
+    encode_decode_mode::<proto::StateKeeper>(&mode_validium);
+}
+
+#[track_caller]
+fn encode_decode_mode<P: ProtoRepr>(mode: &proto::L1BatchCommitDataGeneratorMode)
+where
+    P::Type: PartialEq + std::fmt::Debug + testonly::RandomConfig,
+{
+    for required_only in [false, true] {
+        // Manually set the L1BatchCommitDataGeneratorMode
+        let mut state_keeper = generate_mode(mode);
+        dbg!(state_keeper);
+
+        let rng = &mut rand::thread_rng();
+        let want: P::Type = testonly::Gen {
+            rng,
+            required_only,
+            decimal_fractions: false,
+        }
+        .gen();
+        dbg!(want);
+        assert_eq!(1, 2);
+        //let got = decode::<P>(&encode::<P>(&want)).unwrap();
+
+        //     let got = decode::<P>(&encode::<P>(&state_keeper)).unwrap();
+        //     assert_eq!(&state_keeper, &got, "binary encoding");
+
+        //     let got = decode_json::<P>(&encode_json::<P>(&state_keeper)).unwrap();
+        //     assert_eq!(&state_keeper, &got, "json encoding");
+        //
+    }
+}
+
+fn generate_mode(mode: &proto::L1BatchCommitDataGeneratorMode) -> proto::StateKeeper {
+    proto::StateKeeper {
+        transaction_slots: Some(10926497003267881492),
+        block_commit_deadline_ms: Some(10947007445086036797),
+        miniblock_commit_deadline_ms: Some(9103314936350460727),
+        miniblock_seal_queue_capacity: Some(6906530626745786909),
+        max_single_tx_gas: Some(2785542050),
+        max_allowed_l2_tx_gas_limit: Some(1183074970),
+        reject_tx_at_geometry_percentage: Some(0.5296344133371791),
+        reject_tx_at_eth_params_percentage: Some(0.8773607433255183),
+        reject_tx_at_gas_percentage: Some(0.5289453936748325),
+        close_block_at_geometry_percentage: Some(0.6479326814884391),
+        close_block_at_eth_params_percentage: Some(0.21958980771195413),
+        close_block_at_gas_percentage: Some(0.5229693273318018),
+        fee_account_addr: Some(
+            [
+                153, 251, 1, 240, 243, 248, 139, 100, 180, 119, 34, 199, 146, 251, 165, 177, 250,
+                52, 209, 52,
+            ]
+            .into(),
+        ),
+        minimal_l2_gas_price: Some(2703211627494097776),
+        compute_overhead_part: Some(0.6857318990462495),
+        pubdata_overhead_part: Some(0.12953109152591813),
+        batch_overhead_l1_gas: Some(15518551973209220528),
+        max_gas_per_batch: Some(15859976163468884008),
+        max_pubdata_per_batch: Some(11012258501587398219),
+        fee_model_version: Some(V1.into()),
+        validation_computational_gas_limit: Some(2619723581),
+        save_call_traces: Some(true),
+        virtual_blocks_interval: Some(1113108050),
+        virtual_blocks_per_miniblock: Some(756446353),
+        upload_witness_inputs_to_gcs: Some(true),
+        enum_index_migration_chunk_size: Some(3905631822449257186),
+        l1_batch_commit_data_generator_mode: Some(mode.clone().into()),
+    }
 }

--- a/core/lib/protobuf_config/src/tests.rs
+++ b/core/lib/protobuf_config/src/tests.rs
@@ -110,8 +110,19 @@ where
 {
     for required_only in [false, true] {
         // Manually set the L1BatchCommitDataGeneratorMode
-        let mut state_keeper = generate_mode(mode);
-        dbg!(state_keeper);
+        let state_keeper = generate_mode(mode);
+
+        // Transform to StateKeeperConfig
+        let state_keeper_config = state_keeper.read().unwrap();
+        dbg!(&state_keeper_config);
+
+        // Check that mode in the StateKeeperConfig matches the tested mode
+        let mode_str = format!("{:#?}", mode);
+        let mode_skc_str = format!(
+            "{:#?}",
+            &state_keeper_config.l1_batch_commit_data_generator_mode
+        );
+        assert_eq!(mode_str, mode_skc_str, "check mode");
 
         let rng = &mut rand::thread_rng();
         let want: P::Type = testonly::Gen {
@@ -120,9 +131,10 @@ where
             decimal_fractions: false,
         }
         .gen();
-        dbg!(want);
+
+        dbg!(&want);
         assert_eq!(1, 2);
-        //let got = decode::<P>(&encode::<P>(&want)).unwrap();
+        let got = decode::<P>(&encode::<P>(&want)).unwrap();
 
         //     let got = decode::<P>(&encode::<P>(&state_keeper)).unwrap();
         //     assert_eq!(&state_keeper, &got, "binary encoding");
@@ -167,6 +179,6 @@ fn generate_mode(mode: &proto::L1BatchCommitDataGeneratorMode) -> proto::StateKe
         virtual_blocks_per_miniblock: Some(756446353),
         upload_witness_inputs_to_gcs: Some(true),
         enum_index_migration_chunk_size: Some(3905631822449257186),
-        l1_batch_commit_data_generator_mode: Some(mode.clone().into()),
+        l1_batch_commit_data_generator_mode: Some((*mode).into()),
     }
 }

--- a/core/lib/protobuf_config/src/tests.rs
+++ b/core/lib/protobuf_config/src/tests.rs
@@ -1,9 +1,8 @@
 use pretty_assertions::assert_eq;
 use rand::Rng;
-use testonly::{Gen, RandomConfig};
 use zksync_config::testonly;
 
-use crate::{proto, proto::FeeModelVersion::V1, repr::ProtoRepr};
+use crate::{proto, repr::ProtoRepr};
 
 fn encode<P: ProtoRepr>(msg: &P::Type) -> Vec<u8> {
     let msg = P::build(msg);
@@ -90,95 +89,4 @@ fn test_encoding() {
     encode_decode::<proto::ProofDataHandler>(rng);
     encode_decode::<proto::SnapshotsCreator>(rng);
     encode_decode::<proto::WitnessGenerator>(rng);
-}
-
-#[test]
-fn test_encoding_state_keeper_mode() {
-    // Test Rollup mode
-    let mode_rollup = proto::L1BatchCommitDataGeneratorMode::Rollup;
-    encode_decode_mode::<proto::StateKeeper>(&mode_rollup);
-
-    // Test Validium mode
-    let mode_validium = proto::L1BatchCommitDataGeneratorMode::Validium;
-    encode_decode_mode::<proto::StateKeeper>(&mode_validium);
-}
-
-#[track_caller]
-fn encode_decode_mode<P: ProtoRepr>(mode: &proto::L1BatchCommitDataGeneratorMode)
-where
-    P::Type: PartialEq + std::fmt::Debug + testonly::RandomConfig,
-{
-    for required_only in [false, true] {
-        // Manually set the L1BatchCommitDataGeneratorMode
-        let state_keeper = generate_mode(mode);
-
-        // Transform to StateKeeperConfig
-        let state_keeper_config = state_keeper.read().unwrap();
-        dbg!(&state_keeper_config);
-
-        // Check that mode in the StateKeeperConfig matches the tested mode
-        let mode_str = format!("{:#?}", mode);
-        let mode_skc_str = format!(
-            "{:#?}",
-            &state_keeper_config.l1_batch_commit_data_generator_mode
-        );
-        assert_eq!(mode_str, mode_skc_str, "check mode");
-
-        let rng = &mut rand::thread_rng();
-        let want: P::Type = testonly::Gen {
-            rng,
-            required_only,
-            decimal_fractions: false,
-        }
-        .gen();
-
-        dbg!(&want);
-        assert_eq!(1, 2);
-        let got = decode::<P>(&encode::<P>(&want)).unwrap();
-
-        //     let got = decode::<P>(&encode::<P>(&state_keeper)).unwrap();
-        //     assert_eq!(&state_keeper, &got, "binary encoding");
-
-        //     let got = decode_json::<P>(&encode_json::<P>(&state_keeper)).unwrap();
-        //     assert_eq!(&state_keeper, &got, "json encoding");
-        //
-    }
-}
-
-fn generate_mode(mode: &proto::L1BatchCommitDataGeneratorMode) -> proto::StateKeeper {
-    proto::StateKeeper {
-        transaction_slots: Some(10926497003267881492),
-        block_commit_deadline_ms: Some(10947007445086036797),
-        miniblock_commit_deadline_ms: Some(9103314936350460727),
-        miniblock_seal_queue_capacity: Some(6906530626745786909),
-        max_single_tx_gas: Some(2785542050),
-        max_allowed_l2_tx_gas_limit: Some(1183074970),
-        reject_tx_at_geometry_percentage: Some(0.5296344133371791),
-        reject_tx_at_eth_params_percentage: Some(0.8773607433255183),
-        reject_tx_at_gas_percentage: Some(0.5289453936748325),
-        close_block_at_geometry_percentage: Some(0.6479326814884391),
-        close_block_at_eth_params_percentage: Some(0.21958980771195413),
-        close_block_at_gas_percentage: Some(0.5229693273318018),
-        fee_account_addr: Some(
-            [
-                153, 251, 1, 240, 243, 248, 139, 100, 180, 119, 34, 199, 146, 251, 165, 177, 250,
-                52, 209, 52,
-            ]
-            .into(),
-        ),
-        minimal_l2_gas_price: Some(2703211627494097776),
-        compute_overhead_part: Some(0.6857318990462495),
-        pubdata_overhead_part: Some(0.12953109152591813),
-        batch_overhead_l1_gas: Some(15518551973209220528),
-        max_gas_per_batch: Some(15859976163468884008),
-        max_pubdata_per_batch: Some(11012258501587398219),
-        fee_model_version: Some(V1.into()),
-        validation_computational_gas_limit: Some(2619723581),
-        save_call_traces: Some(true),
-        virtual_blocks_interval: Some(1113108050),
-        virtual_blocks_per_miniblock: Some(756446353),
-        upload_witness_inputs_to_gcs: Some(true),
-        enum_index_migration_chunk_size: Some(3905631822449257186),
-        l1_batch_commit_data_generator_mode: Some((*mode).into()),
-    }
 }


### PR DESCRIPTION
## What ❔

Adapts `protobuf_config` and `testonly.rs` tests for running both in Validium mode and Rollup mode.
Resolves #140.

## Checklist

- [x] Update `protobuf_config` and `testonly.rs` for running both in Validium mode and Rollup mode.

## Testing

```sh
zk test rust --package zksync_protobuf_config --lib -j 1 -- tests
```

