### PR TITLE
fix: Use `zksync_types::Bytes` instead of `Vec<u8>`

### DIFF
--- a/core/lib/web3_decl/src/namespaces/zks.rs
+++ b/core/lib/web3_decl/src/namespaces/zks.rs
@@ -10,7 +10,7 @@ use zksync_types::{
     fee::Fee,
     fee_model::FeeParams,
     transaction_request::CallRequest,
-    Address, L1BatchNumber, MiniblockNumber, H256, U256, U64,
+    Address, Bytes, L1BatchNumber, MiniblockNumber, H256, U256, U64,
 };
 
 use crate::types::Token;
@@ -120,6 +120,5 @@ pub trait ZksNamespace {
     ) -> RpcResult<Proof>;
 
     #[method(name = "getBatchPubdata")]
-    async fn get_batch_pubdata(&self, l1_batch_number: L1BatchNumber)
-        -> RpcResult<Option<Vec<u8>>>;
+    async fn get_batch_pubdata(&self, l1_batch_number: L1BatchNumber) -> RpcResult<Option<Bytes>>;
 }

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -9,7 +9,7 @@ use zksync_types::{
     fee::Fee,
     fee_model::FeeParams,
     transaction_request::CallRequest,
-    Address, L1BatchNumber, MiniblockNumber, H256, U256, U64,
+    Address, Bytes, L1BatchNumber, MiniblockNumber, H256, U256, U64,
 };
 use zksync_web3_decl::{
     jsonrpsee::core::{async_trait, RpcResult},
@@ -169,10 +169,7 @@ impl ZksNamespaceServer for ZksNamespace {
             .map_err(into_jsrpc_error)
     }
 
-    async fn get_batch_pubdata(
-        &self,
-        l1_batch_number: L1BatchNumber,
-    ) -> RpcResult<Option<Vec<u8>>> {
+    async fn get_batch_pubdata(&self, l1_batch_number: L1BatchNumber) -> RpcResult<Option<Bytes>> {
         self.get_batch_pubdata_impl(l1_batch_number)
             .await
             .map_err(into_jsrpc_error)

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -17,8 +17,8 @@ use zksync_types::{
     l2_to_l1_log::L2ToL1Log,
     tokens::ETHEREUM_ADDRESS,
     transaction_request::CallRequest,
-    AccountTreeId, L1BatchNumber, MiniblockNumber, StorageKey, Transaction, L1_MESSENGER_ADDRESS,
-    L2_ETH_TOKEN_ADDRESS, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256, U64,
+    AccountTreeId, Bytes, L1BatchNumber, MiniblockNumber, StorageKey, Transaction,
+    L1_MESSENGER_ADDRESS, L2_ETH_TOKEN_ADDRESS, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256, U64,
 };
 use zksync_utils::{address_to_h256, ratio_to_big_decimal_normalized};
 use zksync_web3_decl::{
@@ -645,7 +645,7 @@ impl ZksNamespace {
     pub async fn get_batch_pubdata_impl(
         &self,
         l1_batch_number: L1BatchNumber,
-    ) -> Result<Option<Vec<u8>>, Web3Error> {
+    ) -> Result<Option<Bytes>, Web3Error> {
         const METHOD_NAME: &str = "get_batch_pubdata";
 
         let method_latency = API_METRICS.start_call(METHOD_NAME);
@@ -656,7 +656,8 @@ impl ZksNamespace {
             .get_l1_batch_metadata(l1_batch_number)
             .await
             .unwrap_or(None);
-        let pubdata = l1_batch_with_metadata.map(|b| L1BatchWithMetadata::construct_pubdata(&b));
+        let pubdata =
+            l1_batch_with_metadata.map(|b| L1BatchWithMetadata::construct_pubdata(&b).into());
 
         method_latency.observe();
         Ok(pubdata)


### PR DESCRIPTION
Resolves #182 