### PR TITLE
fix(validium): Effective gas price calculation

### DIFF
--- a/core/lib/types/src/fee.rs
+++ b/core/lib/types/src/fee.rs
@@ -74,8 +74,14 @@ impl Fee {
         assert!(block_base_fee_per_gas <= self.max_fee_per_gas);
         assert!(self.max_priority_fee_per_gas <= self.max_fee_per_gas);
 
-        // For now, we charge only for base fee.
-        block_base_fee_per_gas
+        // The following calculation is based on the EIP-1559 formula:
+        // https://eips.ethereum.org/EIPS/eip-1559
+        let priority_fee_per_gas = std::cmp::min(
+            self.max_priority_fee_per_gas,
+            self.max_fee_per_gas - block_base_fee_per_gas,
+        );
+
+        block_base_fee_per_gas + priority_fee_per_gas
     }
 }
 


### PR DESCRIPTION
Related to: #107 

To be correctly compatible with legacy transactions, the effective gas calculation should change and follow the specification in:
https://eips.ethereum.org/EIPS/eip-1559

## What ❔

- Changes the formula to calculate the effective gas price.

## Why ❔

- [A test](https://github.com/lambdaclass/zksync-era/blob/fix-effective-gas-price-calculation/core/tests/ts-integration/tests/api/web3.test.ts#L220) that checks the gas price of a transaction (sent vs received in the receipt) was failing in Validium mode since the effective gas price calculation was off.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
