### PR TITLE
feat: Gas oracle - noop conversion rate fetcher

### DIFF
--- a/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs
@@ -25,14 +25,14 @@ pub struct GasAdjuster<E> {
     pub(super) statistics: GasStatistics,
     pub(super) config: GasAdjusterConfig,
     eth_client: E,
-    native_token_fetcher_dyn: Option<Arc<dyn ConversionRateFetcher>>,
+    native_token_fetcher_dyn: Arc<dyn ConversionRateFetcher>,
 }
 
 impl<E: EthInterface> GasAdjuster<E> {
     pub async fn new(
         eth_client: E,
         config: GasAdjusterConfig,
-        native_token_fetcher_dyn: Option<Arc<dyn ConversionRateFetcher>>,
+        native_token_fetcher_dyn: Arc<dyn ConversionRateFetcher>,
     ) -> Result<Self, Error> {
         // Subtracting 1 from the "latest" block number to prevent errors in case
         // the info about the latest block is not yet present on the node.
@@ -131,10 +131,11 @@ impl<E: EthInterface> L1GasPriceProvider for GasAdjuster<E> {
             (self.config.internal_l1_pricing_multiplier * effective_gas_price as f64) as u64;
 
         // Bound the price if it's too high.
-        let conversion_rate = match self.native_token_fetcher_dyn.as_ref() {
-            Some(fetcher) => fetcher.conversion_rate().unwrap_or(1),
-            None => 1,
-        };
+        // let conversion_rate = match self.native_token_fetcher_dyn.as_ref() {
+        //     Some(fetcher) => fetcher.conversion_rate().unwrap_or(1),
+        //     None => 1,
+        // };
+        let conversion_rate = self.native_token_fetcher_dyn.conversion_rate().unwrap_or(1);
 
         self.bound_gas_price(calculated_price) * conversion_rate
     }

--- a/core/lib/zksync_core/src/l1_gas_price/singleton.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/singleton.rs
@@ -17,7 +17,7 @@ pub struct GasAdjusterSingleton {
     web3_url: String,
     gas_adjuster_config: GasAdjusterConfig,
     singleton: OnceCell<Result<Arc<GasAdjuster<QueryClient>>, Error>>,
-    erc20_fetcher_dyn: Option<Arc<dyn ConversionRateFetcher>>,
+    erc20_fetcher_dyn: Arc<dyn ConversionRateFetcher>,
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -34,7 +34,7 @@ impl GasAdjusterSingleton {
     pub fn new(
         web3_url: String,
         gas_adjuster_config: GasAdjusterConfig,
-        erc20_fetcher_dyn: Option<Arc<dyn ConversionRateFetcher>>,
+        erc20_fetcher_dyn: Arc<dyn ConversionRateFetcher>,
     ) -> Self {
         Self {
             web3_url,

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -68,7 +68,9 @@ use crate::{
     l1_gas_price::{GasAdjusterSingleton, L1GasPriceProvider},
     metadata_calculator::{MetadataCalculator, MetadataCalculatorConfig},
     metrics::{InitStage, APP_METRICS},
-    native_token_fetcher::{ConversionRateFetcher, NativeTokenFetcherSingleton},
+    native_token_fetcher::{
+        ConversionRateFetcher, NativeTokenFetcherSingleton, NoOpConversionRateFetcher,
+    },
     state_keeper::{
         create_state_keeper, MempoolFetcher, MempoolGuard, MiniblockSealer, SequencerSealer,
     },
@@ -340,19 +342,19 @@ pub async fn initialize_components(
     let (stop_sender, stop_receiver) = watch::channel(false);
     let (cb_sender, cb_receiver) = oneshot::channel();
 
-    let native_token_fetcher = if let Some(fetcher_singleton) = &mut fetcher_component {
-        let fetcher = fetcher_singleton
-            .get_or_init()
-            .await
-            .context("fetcher.get_or_init()")?;
-        Some(fetcher)
-    } else {
-        None
-    };
+    let native_token_fetcher: Arc<dyn ConversionRateFetcher> =
+        if let Some(fetcher_singleton) = &mut fetcher_component {
+            let fetcher = fetcher_singleton
+                .get_or_init()
+                .await
+                .context("fetcher.get_or_init()")?;
+            fetcher
+        } else {
+            // create no-op fetcher if the native token fetcher is not enabled
+            Arc::new(NoOpConversionRateFetcher::new())
+        };
 
-    let erc20_fetcher_dyn: Option<Arc<dyn ConversionRateFetcher>> = native_token_fetcher
-        .as_ref()
-        .map(|fetcher| fetcher.clone() as Arc<dyn ConversionRateFetcher>);
+    let erc20_fetcher_dyn: Arc<dyn ConversionRateFetcher> = native_token_fetcher.clone();
 
     let query_client = QueryClient::new(&eth_client_config.web3_url).unwrap();
     let gas_adjuster_config = configs.gas_adjuster_config.context("gas_adjuster_config")?;

--- a/core/lib/zksync_core/src/native_token_fetcher/mod.rs
+++ b/core/lib/zksync_core/src/native_token_fetcher/mod.rs
@@ -26,6 +26,22 @@ pub trait ConversionRateFetcher: 'static + std::fmt::Debug + Send + Sync {
     fn conversion_rate(&self) -> anyhow::Result<u64>;
 }
 
+#[derive(Debug)]
+pub(crate) struct NoOpConversionRateFetcher;
+
+impl NoOpConversionRateFetcher {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ConversionRateFetcher for NoOpConversionRateFetcher {
+    fn conversion_rate(&self) -> anyhow::Result<u64> {
+        Ok(1)
+    }
+}
+
 pub(crate) struct NativeTokenFetcherSingleton {
     native_token_fetcher_config: NativeTokenFetcherConfig,
     singleton: OnceCell<Result<Arc<NativeTokenFetcher>, Error>>,


### PR DESCRIPTION
Closes #192 

## What ❔

Implement a struct which implements `ConversionRateFetcher` that always returns `1` when `conversion_rate()`.

## Why ❔

Make `Erc20Fetcher` mandatory.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zk fmt` and `zk lint`.
