### PR TITLE
Add initial tests folder from vm_latest

### DIFF
--- a/core/lib/multivm/src/versions/era_vm/mod.rs
+++ b/core/lib/multivm/src/versions/era_vm/mod.rs
@@ -1,5 +1,7 @@
 mod bytecode;
 mod initial_bootloader_memory;
 mod snapshot;
+#[cfg(test)]
+mod tests;
 mod transaction_data;
 pub mod vm;

--- a/core/lib/multivm/src/versions/era_vm/tests/block_tip.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/block_tip.rs
@@ -1,0 +1,428 @@
+use std::borrow::BorrowMut;
+
+use ethabi::Token;
+use itertools::Itertools;
+use zk_evm_1_5_0::aux_structures::Timestamp;
+use zksync_contracts::load_sys_contract;
+use zksync_system_constants::{
+    CONTRACT_FORCE_DEPLOYER_ADDRESS, KNOWN_CODES_STORAGE_ADDRESS, L1_MESSENGER_ADDRESS,
+};
+use zksync_types::{
+    commitment::SerializeCommitment, fee_model::BatchFeeInput, get_code_key,
+    l2_to_l1_log::L2ToL1Log, writes::StateDiffRecord, Address, Execute, H256, U256,
+};
+use zksync_utils::{bytecode::hash_bytecode, bytes_to_be_words, h256_to_u256, u256_to_h256};
+
+use super::utils::{get_complex_upgrade_abi, read_complex_upgrade};
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        constants::{
+            BOOTLOADER_BATCH_TIP_CIRCUIT_STATISTICS_OVERHEAD,
+            BOOTLOADER_BATCH_TIP_METRICS_SIZE_OVERHEAD, BOOTLOADER_BATCH_TIP_OVERHEAD,
+            MAX_VM_PUBDATA_PER_BATCH,
+        },
+        tests::tester::{
+            default_l1_batch, get_empty_storage, InMemoryStorageView, VmTesterBuilder,
+        },
+        tracers::PubdataTracer,
+        HistoryEnabled, L1BatchEnv, TracerDispatcher,
+    },
+};
+
+#[derive(Debug, Clone, Default)]
+struct L1MessengerTestData {
+    l2_to_l1_logs: usize,
+    messages: Vec<Vec<u8>>,
+    bytecodes: Vec<Vec<u8>>,
+    state_diffs: Vec<StateDiffRecord>,
+}
+
+struct MimicCallInfo {
+    to: Address,
+    who_to_mimic: Address,
+    data: Vec<u8>,
+}
+
+const CALLS_PER_TX: usize = 1_000;
+fn populate_mimic_calls(data: L1MessengerTestData) -> Vec<Vec<u8>> {
+    let complex_upgrade = get_complex_upgrade_abi();
+    let l1_messenger = load_sys_contract("L1Messenger");
+
+    let logs_mimic_calls = (0..data.l2_to_l1_logs).map(|_| MimicCallInfo {
+        to: L1_MESSENGER_ADDRESS,
+        who_to_mimic: KNOWN_CODES_STORAGE_ADDRESS,
+        data: l1_messenger
+            .function("sendL2ToL1Log")
+            .unwrap()
+            .encode_input(&[
+                Token::Bool(false),
+                Token::FixedBytes(H256::random().0.to_vec()),
+                Token::FixedBytes(H256::random().0.to_vec()),
+            ])
+            .unwrap(),
+    });
+    let messages_mimic_calls = data.messages.iter().map(|message| MimicCallInfo {
+        to: L1_MESSENGER_ADDRESS,
+        who_to_mimic: KNOWN_CODES_STORAGE_ADDRESS,
+        data: l1_messenger
+            .function("sendToL1")
+            .unwrap()
+            .encode_input(&[Token::Bytes(message.clone())])
+            .unwrap(),
+    });
+    let bytecodes_mimic_calls = data.bytecodes.iter().map(|bytecode| MimicCallInfo {
+        to: L1_MESSENGER_ADDRESS,
+        who_to_mimic: KNOWN_CODES_STORAGE_ADDRESS,
+        data: l1_messenger
+            .function("requestBytecodeL1Publication")
+            .unwrap()
+            .encode_input(&[Token::FixedBytes(hash_bytecode(bytecode).0.to_vec())])
+            .unwrap(),
+    });
+
+    let encoded_calls = logs_mimic_calls
+        .chain(messages_mimic_calls)
+        .chain(bytecodes_mimic_calls)
+        .map(|call| {
+            Token::Tuple(vec![
+                Token::Address(call.to),
+                Token::Address(call.who_to_mimic),
+                Token::Bytes(call.data),
+            ])
+        })
+        .chunks(CALLS_PER_TX)
+        .into_iter()
+        .map(|chunk| {
+            complex_upgrade
+                .function("mimicCalls")
+                .unwrap()
+                .encode_input(&[Token::Array(chunk.collect_vec())])
+                .unwrap()
+        })
+        .collect_vec();
+
+    encoded_calls
+}
+
+struct TestStatistics {
+    pub max_used_gas: u32,
+    pub circuit_statistics: u64,
+    pub execution_metrics_size: u64,
+}
+
+struct StatisticsTagged {
+    pub statistics: TestStatistics,
+    pub tag: String,
+}
+
+fn execute_test(test_data: L1MessengerTestData) -> TestStatistics {
+    let mut storage = get_empty_storage();
+    let complex_upgrade_code = read_complex_upgrade();
+
+    // For this test we'll just put the bytecode onto the force deployer address
+    storage.borrow_mut().set_value(
+        get_code_key(&CONTRACT_FORCE_DEPLOYER_ADDRESS),
+        hash_bytecode(&complex_upgrade_code),
+    );
+    storage
+        .borrow_mut()
+        .store_factory_dep(hash_bytecode(&complex_upgrade_code), complex_upgrade_code);
+
+    // We are measuring computational cost, so prices for pubdata don't matter, while they artificially dilute
+    // the gas limit
+
+    let batch_env = L1BatchEnv {
+        fee_input: BatchFeeInput::pubdata_independent(100_000, 100_000, 100_000),
+        ..default_l1_batch(zksync_types::L1BatchNumber(1))
+    };
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_storage(storage)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .with_l1_batch_env(batch_env)
+        .build();
+
+    let bytecodes = test_data
+        .bytecodes
+        .iter()
+        .map(|bytecode| {
+            let hash = hash_bytecode(bytecode);
+            let words = bytes_to_be_words(bytecode.clone());
+            (h256_to_u256(hash), words)
+        })
+        .collect();
+    vm.vm
+        .state
+        .decommittment_processor
+        .populate(bytecodes, Timestamp(0));
+
+    let txs_data = populate_mimic_calls(test_data.clone());
+    let account = &mut vm.rich_accounts[0];
+
+    for (i, data) in txs_data.into_iter().enumerate() {
+        let tx = account.get_l2_tx_for_execute(
+            Execute {
+                contract_address: CONTRACT_FORCE_DEPLOYER_ADDRESS,
+                calldata: data,
+                value: U256::zero(),
+                factory_deps: vec![],
+            },
+            None,
+        );
+
+        vm.vm.push_transaction(tx);
+
+        let result = vm.vm.execute(VmExecutionMode::OneTx);
+        assert!(
+            !result.result.is_failed(),
+            "Transaction {i} wasn't successful for input: {:#?}",
+            test_data
+        );
+    }
+
+    // Now we count how much ergs were spent at the end of the batch
+    // It is assumed that the top level frame is the bootloader
+
+    let ergs_before = vm.vm.state.local_state.callstack.current.ergs_remaining;
+
+    // We ensure that indeed the provided state diffs are used
+    let pubdata_tracer = PubdataTracer::<InMemoryStorageView>::new_with_forced_state_diffs(
+        vm.vm.batch_env.clone(),
+        VmExecutionMode::Batch,
+        test_data.state_diffs.clone(),
+        crate::vm_latest::MultiVMSubversion::latest(),
+    );
+
+    let result = vm.vm.inspect_inner(
+        TracerDispatcher::default(),
+        VmExecutionMode::Batch,
+        Some(pubdata_tracer),
+    );
+
+    assert!(
+        !result.result.is_failed(),
+        "Batch wasn't successful for input: {:?}",
+        test_data
+    );
+
+    let ergs_after = vm.vm.state.local_state.callstack.current.ergs_remaining;
+
+    assert_eq!(
+        (ergs_before - ergs_after) as u64,
+        result.statistics.gas_used
+    );
+
+    TestStatistics {
+        max_used_gas: ergs_before - ergs_after,
+        circuit_statistics: result.statistics.circuit_statistic.total() as u64,
+        execution_metrics_size: result.get_execution_metrics(None).size() as u64,
+    }
+}
+
+fn generate_state_diffs(
+    repeated_writes: bool,
+    small_diff: bool,
+    number_of_state_diffs: usize,
+) -> Vec<StateDiffRecord> {
+    (0..number_of_state_diffs)
+        .map(|i| {
+            let address = Address::from_low_u64_be(i as u64);
+            let key = U256::from(i);
+            let enumeration_index = if repeated_writes { i + 1 } else { 0 };
+
+            let (initial_value, final_value) = if small_diff {
+                // As small as it gets, one byte to denote zeroing out the value
+                (U256::from(1), U256::from(0))
+            } else {
+                // As large as it gets
+                (U256::from(0), U256::from(2).pow(255.into()))
+            };
+
+            StateDiffRecord {
+                address,
+                key,
+                derived_key: u256_to_h256(i.into()).0,
+                enumeration_index: enumeration_index as u64,
+                initial_value,
+                final_value,
+            }
+        })
+        .collect()
+}
+
+// A valid zkEVM bytecode has odd number of 32 byte words
+fn get_valid_bytecode_length(length: usize) -> usize {
+    // Firstly ensure that the length is divisible by 32
+    let length_padded_to_32 = if length % 32 == 0 {
+        length
+    } else {
+        length + 32 - (length % 32)
+    };
+
+    // Then we ensure that the number returned by division by 32 is odd
+    if length_padded_to_32 % 64 == 0 {
+        length_padded_to_32 + 32
+    } else {
+        length_padded_to_32
+    }
+}
+
+#[test]
+fn test_dry_run_upper_bound() {
+    // Some of the pubdata is consumed by constant fields (such as length of messages, number of logs, etc.).
+    // While this leaves some room for error, at the end of the test we require that the `BOOTLOADER_BATCH_TIP_OVERHEAD`
+    // is sufficient with a very large margin, so it is okay to ignore 1% of possible pubdata.
+    const MAX_EFFECTIVE_PUBDATA_PER_BATCH: usize =
+        (MAX_VM_PUBDATA_PER_BATCH as f64 * 0.99) as usize;
+
+    // We are re-using the `ComplexUpgrade` contract as it already has the `mimicCall` functionality.
+    // To get the upper bound, we'll try to do the following:
+    // 1. Max number of logs.
+    // 2. Lots of small L2->L1 messages / one large L2->L1 message.
+    // 3. Lots of small bytecodes / one large bytecode.
+    // 4. Lots of storage slot updates.
+
+    let statistics = vec![
+        // max logs
+        StatisticsTagged {
+            statistics: execute_test(L1MessengerTestData {
+                l2_to_l1_logs: MAX_EFFECTIVE_PUBDATA_PER_BATCH / L2ToL1Log::SERIALIZED_SIZE,
+                ..Default::default()
+            }),
+            tag: "max_logs".to_string(),
+        },
+        // max messages
+        StatisticsTagged {
+            statistics: execute_test(L1MessengerTestData {
+                // Each L2->L1 message is accompanied by a Log + its length, which is a 4 byte number,
+                // so the max number of pubdata is bound by it
+                messages: vec![
+                    vec![0; 0];
+                    MAX_EFFECTIVE_PUBDATA_PER_BATCH / (L2ToL1Log::SERIALIZED_SIZE + 4)
+                ],
+                ..Default::default()
+            }),
+            tag: "max_messages".to_string(),
+        },
+        // long message
+        StatisticsTagged {
+            statistics: execute_test(L1MessengerTestData {
+                // Each L2->L1 message is accompanied by a Log, so the max number of pubdata is bound by it
+                messages: vec![vec![0; MAX_EFFECTIVE_PUBDATA_PER_BATCH]; 1],
+                ..Default::default()
+            }),
+            tag: "long_message".to_string(),
+        },
+        // max bytecodes
+        StatisticsTagged {
+            statistics: execute_test(L1MessengerTestData {
+                // Each bytecode must be at least 32 bytes long.
+                // Each uncompressed bytecode is accompanied by its length, which is a 4 byte number
+                bytecodes: vec![vec![0; 32]; MAX_EFFECTIVE_PUBDATA_PER_BATCH / (32 + 4)],
+                ..Default::default()
+            }),
+            tag: "max_bytecodes".to_string(),
+        },
+        // long bytecode
+        StatisticsTagged {
+            statistics: execute_test(L1MessengerTestData {
+                bytecodes: vec![
+                    vec![0; get_valid_bytecode_length(MAX_EFFECTIVE_PUBDATA_PER_BATCH)];
+                    1
+                ],
+                ..Default::default()
+            }),
+            tag: "long_bytecode".to_string(),
+        },
+        // lots of small repeated writes
+        StatisticsTagged {
+            statistics: execute_test(L1MessengerTestData {
+                // In theory each state diff can require only 5 bytes to be published (enum index + 4 bytes for the key)
+                state_diffs: generate_state_diffs(true, true, MAX_EFFECTIVE_PUBDATA_PER_BATCH / 5),
+                ..Default::default()
+            }),
+            tag: "small_repeated_writes".to_string(),
+        },
+        // lots of big repeated writes
+        StatisticsTagged {
+            statistics: execute_test(L1MessengerTestData {
+                // Each big repeated write will approximately require 4 bytes for key + 1 byte for encoding type + 32 bytes for value
+                state_diffs: generate_state_diffs(
+                    true,
+                    false,
+                    MAX_EFFECTIVE_PUBDATA_PER_BATCH / 37,
+                ),
+                ..Default::default()
+            }),
+            tag: "big_repeated_writes".to_string(),
+        },
+        // lots of small initial writes
+        StatisticsTagged {
+            statistics: execute_test(L1MessengerTestData {
+                // Each small initial write will take at least 32 bytes for derived key + 1 bytes encoding zeroing out
+                state_diffs: generate_state_diffs(
+                    false,
+                    true,
+                    MAX_EFFECTIVE_PUBDATA_PER_BATCH / 33,
+                ),
+                ..Default::default()
+            }),
+            tag: "small_initial_writes".to_string(),
+        },
+        // lots of large initial writes
+        StatisticsTagged {
+            statistics: execute_test(L1MessengerTestData {
+                // Each big write will take at least 32 bytes for derived key + 1 byte for encoding type + 32 bytes for value
+                state_diffs: generate_state_diffs(
+                    false,
+                    false,
+                    MAX_EFFECTIVE_PUBDATA_PER_BATCH / 65,
+                ),
+                ..Default::default()
+            }),
+            tag: "big_initial_writes".to_string(),
+        },
+    ];
+
+    // We use 2x overhead for the batch tip compared to the worst estimated scenario.
+    let max_used_gas = statistics
+        .iter()
+        .map(|s| (s.statistics.max_used_gas, s.tag.clone()))
+        .max()
+        .unwrap();
+    assert!(
+        max_used_gas.0 * 3 / 2 <= BOOTLOADER_BATCH_TIP_OVERHEAD,
+        "BOOTLOADER_BATCH_TIP_OVERHEAD is too low for {} with result {}, BOOTLOADER_BATCH_TIP_OVERHEAD = {}",
+        max_used_gas.1,
+        max_used_gas.0,
+        BOOTLOADER_BATCH_TIP_OVERHEAD
+    );
+
+    let circuit_statistics = statistics
+        .iter()
+        .map(|s| (s.statistics.circuit_statistics, s.tag.clone()))
+        .max()
+        .unwrap();
+    assert!(
+        circuit_statistics.0 * 3 / 2 <= BOOTLOADER_BATCH_TIP_CIRCUIT_STATISTICS_OVERHEAD as u64,
+        "BOOTLOADER_BATCH_TIP_CIRCUIT_STATISTICS_OVERHEAD is too low for {} with result {}, BOOTLOADER_BATCH_TIP_CIRCUIT_STATISTICS_OVERHEAD = {}",
+        circuit_statistics.1,
+        circuit_statistics.0,
+        BOOTLOADER_BATCH_TIP_CIRCUIT_STATISTICS_OVERHEAD
+    );
+
+    let execution_metrics_size = statistics
+        .iter()
+        .map(|s| (s.statistics.execution_metrics_size, s.tag.clone()))
+        .max()
+        .unwrap();
+    assert!(
+        execution_metrics_size.0 * 3 / 2 <= BOOTLOADER_BATCH_TIP_METRICS_SIZE_OVERHEAD as u64,
+        "BOOTLOADER_BATCH_TIP_METRICS_SIZE_OVERHEAD is too low for {} with result {}, BOOTLOADER_BATCH_TIP_METRICS_SIZE_OVERHEAD = {}",
+        execution_metrics_size.1,
+        execution_metrics_size.0,
+        BOOTLOADER_BATCH_TIP_METRICS_SIZE_OVERHEAD
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/bootloader.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/bootloader.rs
@@ -1,0 +1,56 @@
+use zksync_types::U256;
+
+use crate::{
+    interface::{ExecutionResult, Halt, TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        constants::BOOTLOADER_HEAP_PAGE,
+        tests::{
+            tester::VmTesterBuilder,
+            utils::{get_bootloader, verify_required_memory, BASE_SYSTEM_CONTRACTS},
+        },
+        HistoryEnabled,
+    },
+};
+
+#[test]
+fn test_dummy_bootloader() {
+    let mut base_system_contracts = BASE_SYSTEM_CONTRACTS.clone();
+    base_system_contracts.bootloader = get_bootloader("dummy");
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_base_system_smart_contracts(base_system_contracts)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .build();
+
+    let result = vm.vm.execute(VmExecutionMode::Batch);
+    assert!(!result.result.is_failed());
+
+    let correct_first_cell = U256::from_str_radix("123123123", 16).unwrap();
+    verify_required_memory(
+        &vm.vm.state,
+        vec![(correct_first_cell, BOOTLOADER_HEAP_PAGE, 0)],
+    );
+}
+
+#[test]
+fn test_bootloader_out_of_gas() {
+    let mut base_system_contracts = BASE_SYSTEM_CONTRACTS.clone();
+    base_system_contracts.bootloader = get_bootloader("dummy");
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_base_system_smart_contracts(base_system_contracts)
+        .with_bootloader_gas_limit(10)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .build();
+
+    let res = vm.vm.execute(VmExecutionMode::Batch);
+
+    assert!(matches!(
+        res.result,
+        ExecutionResult::Halt {
+            reason: Halt::BootloaderOutOfGas
+        }
+    ));
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/bytecode_publishing.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/bytecode_publishing.rs
@@ -1,0 +1,43 @@
+use zksync_types::event::extract_long_l2_to_l1_messages;
+use zksync_utils::bytecode::compress_bytecode;
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{DeployContractsTx, TxType, VmTesterBuilder},
+            utils::read_test_contract,
+        },
+        HistoryEnabled,
+    },
+};
+
+#[test]
+fn test_bytecode_publishing() {
+    // In this test, we aim to ensure that the contents of the compressed bytecodes
+    // are included as part of the L2->L1 long messages
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let counter = read_test_contract();
+    let account = &mut vm.rich_accounts[0];
+
+    let compressed_bytecode = compress_bytecode(&counter).unwrap();
+
+    let DeployContractsTx { tx, .. } = account.get_deploy_tx(&counter, None, TxType::L2);
+    vm.vm.push_transaction(tx);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed(), "Transaction wasn't successful");
+
+    vm.vm.execute(VmExecutionMode::Batch);
+
+    let state = vm.vm.get_current_execution_state();
+    let long_messages = extract_long_l2_to_l1_messages(&state.events);
+    assert!(
+        long_messages.contains(&compressed_bytecode),
+        "Bytecode not published"
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/call_tracer.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/call_tracer.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use once_cell::sync::OnceCell;
+use zksync_types::{Address, Execute};
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    tracers::CallTracer,
+    vm_latest::{
+        constants::BATCH_COMPUTATIONAL_GAS_LIMIT,
+        tests::{
+            tester::VmTesterBuilder,
+            utils::{read_max_depth_contract, read_test_contract},
+        },
+        HistoryEnabled, ToTracerPointer,
+    },
+};
+
+// This test is ultra slow, so it's ignored by default.
+#[test]
+#[ignore]
+fn test_max_depth() {
+    let contarct = read_max_depth_contract();
+    let address = Address::random();
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_random_rich_accounts(1)
+        .with_deployer()
+        .with_bootloader_gas_limit(BATCH_COMPUTATIONAL_GAS_LIMIT)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_custom_contracts(vec![(contarct, address, true)])
+        .build();
+
+    let account = &mut vm.rich_accounts[0];
+    let tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: address,
+            calldata: vec![],
+            value: Default::default(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    let result = Arc::new(OnceCell::new());
+    let call_tracer = CallTracer::new(result.clone()).into_tracer_pointer();
+    vm.vm.push_transaction(tx);
+    let res = vm.vm.inspect(call_tracer.into(), VmExecutionMode::OneTx);
+    assert!(result.get().is_some());
+    assert!(res.result.is_failed());
+}
+
+#[test]
+fn test_basic_behavior() {
+    let contarct = read_test_contract();
+    let address = Address::random();
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_random_rich_accounts(1)
+        .with_deployer()
+        .with_bootloader_gas_limit(BATCH_COMPUTATIONAL_GAS_LIMIT)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_custom_contracts(vec![(contarct, address, true)])
+        .build();
+
+    let increment_by_6_calldata =
+        "7cf5dab00000000000000000000000000000000000000000000000000000000000000006";
+
+    let account = &mut vm.rich_accounts[0];
+    let tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: address,
+            calldata: hex::decode(increment_by_6_calldata).unwrap(),
+            value: Default::default(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    let result = Arc::new(OnceCell::new());
+    let call_tracer = CallTracer::new(result.clone()).into_tracer_pointer();
+    vm.vm.push_transaction(tx);
+    let res = vm.vm.inspect(call_tracer.into(), VmExecutionMode::OneTx);
+
+    let call_tracer_result = result.get().unwrap();
+
+    assert_eq!(call_tracer_result.len(), 1);
+    // Expect that there are a plenty of subcalls underneath.
+    let subcall = &call_tracer_result[0].calls;
+    assert!(subcall.len() > 10);
+    assert!(!res.result.is_failed());
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/circuits.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/circuits.rs
@@ -1,0 +1,74 @@
+use zksync_types::{Address, Execute, U256};
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        constants::BATCH_COMPUTATIONAL_GAS_LIMIT, tests::tester::VmTesterBuilder, HistoryEnabled,
+    },
+};
+
+// Checks that estimated number of circuits for simple transfer doesn't differ much
+// from hardcoded expected value.
+#[test]
+fn test_circuits() {
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_random_rich_accounts(1)
+        .with_deployer()
+        .with_bootloader_gas_limit(BATCH_COMPUTATIONAL_GAS_LIMIT)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .build();
+
+    let account = &mut vm.rich_accounts[0];
+    let tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: Address::random(),
+            calldata: Vec::new(),
+            value: U256::from(1u8),
+            factory_deps: vec![],
+        },
+        None,
+    );
+    vm.vm.push_transaction(tx);
+    let res = vm.vm.inspect(Default::default(), VmExecutionMode::OneTx);
+
+    let s = res.statistics.circuit_statistic;
+    // Check `circuit_statistic`.
+    const EXPECTED: [f32; 13] = [
+        1.34935, 0.15026, 1.66666, 0.00315, 1.0594, 0.00058, 0.00348, 0.00076, 0.11945, 0.14285,
+        0.0, 0.0, 0.0,
+    ];
+    let actual = [
+        (s.main_vm, "main_vm"),
+        (s.ram_permutation, "ram_permutation"),
+        (s.storage_application, "storage_application"),
+        (s.storage_sorter, "storage_sorter"),
+        (s.code_decommitter, "code_decommitter"),
+        (s.code_decommitter_sorter, "code_decommitter_sorter"),
+        (s.log_demuxer, "log_demuxer"),
+        (s.events_sorter, "events_sorter"),
+        (s.keccak256, "keccak256"),
+        (s.ecrecover, "ecrecover"),
+        (s.sha256, "sha256"),
+        (s.secp256k1_verify, "secp256k1_verify"),
+        (s.transient_storage_checker, "transient_storage_checker"),
+    ];
+    for ((actual, name), expected) in actual.iter().zip(EXPECTED) {
+        if expected == 0.0 {
+            assert_eq!(
+                *actual, expected,
+                "Check failed for {}, expected {}, actual {}",
+                name, expected, actual
+            );
+        } else {
+            let diff = (actual - expected) / expected;
+            assert!(
+                diff.abs() < 0.1,
+                "Check failed for {}, expected {}, actual {}",
+                name,
+                expected,
+                actual
+            );
+        }
+    }
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/code_oracle.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/code_oracle.rs
@@ -1,0 +1,166 @@
+use ethabi::Token;
+use zk_evm_1_5_0::aux_structures::Timestamp;
+use zksync_types::{get_known_code_key, web3::keccak256, Address, Execute, U256};
+use zksync_utils::{bytecode::hash_bytecode, bytes_to_be_words, h256_to_u256, u256_to_h256};
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{get_empty_storage, VmTesterBuilder},
+            utils::{load_precompiles_contract, read_precompiles_contract, read_test_contract},
+        },
+        HistoryEnabled,
+    },
+};
+
+fn generate_large_bytecode() -> Vec<u8> {
+    // This is the maximal possible size of a zkEVM bytecode
+    vec![2u8; ((1 << 16) - 1) * 32]
+}
+
+#[test]
+fn test_code_oracle() {
+    let precompiles_contract_address = Address::random();
+    let precompile_contract_bytecode = read_precompiles_contract();
+
+    // Filling the zkevm bytecode
+    let normal_zkevm_bytecode = read_test_contract();
+    let normal_zkevm_bytecode_hash = hash_bytecode(&normal_zkevm_bytecode);
+    let normal_zkevm_bytecode_keccak_hash = keccak256(&normal_zkevm_bytecode);
+    let mut storage = get_empty_storage();
+    storage.set_value(
+        get_known_code_key(&normal_zkevm_bytecode_hash),
+        u256_to_h256(U256::one()),
+    );
+
+    // In this test, we aim to test whether a simple account interaction (without any fee logic)
+    // will work. The account will try to deploy a simple contract from integration tests.
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .with_custom_contracts(vec![(
+            precompile_contract_bytecode,
+            precompiles_contract_address,
+            false,
+        )])
+        .with_storage(storage)
+        .build();
+
+    let precompile_contract = load_precompiles_contract();
+    let call_code_oracle_function = precompile_contract.function("callCodeOracle").unwrap();
+
+    vm.vm.state.decommittment_processor.populate(
+        vec![(
+            h256_to_u256(normal_zkevm_bytecode_hash),
+            bytes_to_be_words(normal_zkevm_bytecode),
+        )],
+        Timestamp(0),
+    );
+
+    let account = &mut vm.rich_accounts[0];
+
+    // Firstly, let's ensure that the contract works.
+    let tx1 = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: precompiles_contract_address,
+            calldata: call_code_oracle_function
+                .encode_input(&[
+                    Token::FixedBytes(normal_zkevm_bytecode_hash.0.to_vec()),
+                    Token::FixedBytes(normal_zkevm_bytecode_keccak_hash.to_vec()),
+                ])
+                .unwrap(),
+            value: U256::zero(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    vm.vm.push_transaction(tx1);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed(), "Transaction wasn't successful");
+
+    // Now, we ask for the same bytecode. We use to partially check whether the memory page with
+    // the decommitted bytecode gets erased (it shouldn't).
+    let tx2 = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: precompiles_contract_address,
+            calldata: call_code_oracle_function
+                .encode_input(&[
+                    Token::FixedBytes(normal_zkevm_bytecode_hash.0.to_vec()),
+                    Token::FixedBytes(normal_zkevm_bytecode_keccak_hash.to_vec()),
+                ])
+                .unwrap(),
+            value: U256::zero(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+    vm.vm.push_transaction(tx2);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed(), "Transaction wasn't successful");
+}
+
+#[test]
+fn test_code_oracle_big_bytecode() {
+    let precompiles_contract_address = Address::random();
+    let precompile_contract_bytecode = read_precompiles_contract();
+
+    let big_zkevm_bytecode = generate_large_bytecode();
+    let big_zkevm_bytecode_hash = hash_bytecode(&big_zkevm_bytecode);
+    let big_zkevm_bytecode_keccak_hash = keccak256(&big_zkevm_bytecode);
+
+    let mut storage = get_empty_storage();
+    storage.set_value(
+        get_known_code_key(&big_zkevm_bytecode_hash),
+        u256_to_h256(U256::one()),
+    );
+
+    // In this test, we aim to test whether a simple account interaction (without any fee logic)
+    // will work. The account will try to deploy a simple contract from integration tests.
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .with_custom_contracts(vec![(
+            precompile_contract_bytecode,
+            precompiles_contract_address,
+            false,
+        )])
+        .with_storage(storage)
+        .build();
+
+    let precompile_contract = load_precompiles_contract();
+    let call_code_oracle_function = precompile_contract.function("callCodeOracle").unwrap();
+
+    vm.vm.state.decommittment_processor.populate(
+        vec![(
+            h256_to_u256(big_zkevm_bytecode_hash),
+            bytes_to_be_words(big_zkevm_bytecode),
+        )],
+        Timestamp(0),
+    );
+
+    let account = &mut vm.rich_accounts[0];
+
+    // Firstly, let's ensure that the contract works.
+    let tx1 = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: precompiles_contract_address,
+            calldata: call_code_oracle_function
+                .encode_input(&[
+                    Token::FixedBytes(big_zkevm_bytecode_hash.0.to_vec()),
+                    Token::FixedBytes(big_zkevm_bytecode_keccak_hash.to_vec()),
+                ])
+                .unwrap(),
+            value: U256::zero(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    vm.vm.push_transaction(tx1);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed(), "Transaction wasn't successful");
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/constants.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/constants.rs
@@ -1,0 +1,9 @@
+/// Some of the constants of the system are implicitly calculated, but they may affect the code and so
+/// we added additional checks on them to keep any unwanted changes of those apparent.
+#[test]
+fn test_that_bootloader_encoding_space_is_large_enoguh() {
+    let encoding_space = crate::vm_latest::constants::get_bootloader_tx_encoding_space(
+        crate::vm_latest::MultiVMSubversion::latest(),
+    );
+    assert!(encoding_space >= 330000, "Bootloader tx space is too small");
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/default_aa.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/default_aa.rs
@@ -1,0 +1,79 @@
+use zksync_system_constants::L2_BASE_TOKEN_ADDRESS;
+use zksync_types::{
+    get_code_key, get_known_code_key, get_nonce_key,
+    system_contracts::{DEPLOYMENT_NONCE_INCREMENT, TX_NONCE_INCREMENT},
+    AccountTreeId, U256,
+};
+use zksync_utils::u256_to_h256;
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{DeployContractsTx, TxType, VmTesterBuilder},
+            utils::{get_balance, read_test_contract, verify_required_storage},
+        },
+        utils::fee::get_batch_base_fee,
+        HistoryEnabled,
+    },
+};
+
+#[test]
+fn test_default_aa_interaction() {
+    // In this test, we aim to test whether a simple account interaction (without any fee logic)
+    // will work. The account will try to deploy a simple contract from integration tests.
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let counter = read_test_contract();
+    let account = &mut vm.rich_accounts[0];
+    let DeployContractsTx {
+        tx,
+        bytecode_hash,
+        address,
+    } = account.get_deploy_tx(&counter, None, TxType::L2);
+    let maximal_fee = tx.gas_limit() * get_batch_base_fee(&vm.vm.batch_env);
+
+    vm.vm.push_transaction(tx);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed(), "Transaction wasn't successful");
+
+    vm.vm.execute(VmExecutionMode::Batch);
+
+    vm.vm.get_current_execution_state();
+
+    // Both deployment and ordinary nonce should be incremented by one.
+    let account_nonce_key = get_nonce_key(&account.address);
+    let expected_nonce = TX_NONCE_INCREMENT + DEPLOYMENT_NONCE_INCREMENT;
+
+    // The code hash of the deployed contract should be marked as republished.
+    let known_codes_key = get_known_code_key(&bytecode_hash);
+
+    // The contract should be deployed successfully.
+    let account_code_key = get_code_key(&address);
+
+    let expected_slots = vec![
+        (u256_to_h256(expected_nonce), account_nonce_key),
+        (u256_to_h256(U256::from(1u32)), known_codes_key),
+        (bytecode_hash, account_code_key),
+    ];
+
+    verify_required_storage(&vm.vm.state, expected_slots);
+
+    let expected_fee = maximal_fee
+        - U256::from(result.refunds.gas_refunded)
+            * U256::from(get_batch_base_fee(&vm.vm.batch_env));
+    let operator_balance = get_balance(
+        AccountTreeId::new(L2_BASE_TOKEN_ADDRESS),
+        &vm.fee_account,
+        vm.vm.state.storage.storage.get_ptr(),
+    );
+
+    assert_eq!(
+        operator_balance, expected_fee,
+        "Operator did not receive his fee"
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/gas_limit.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/gas_limit.rs
@@ -1,0 +1,43 @@
+use zksync_test_account::Account;
+use zksync_types::{fee::Fee, Execute};
+
+use crate::{
+    interface::{TxExecutionMode, VmInterface},
+    vm_latest::{
+        constants::{BOOTLOADER_HEAP_PAGE, TX_DESCRIPTION_OFFSET, TX_GAS_LIMIT_OFFSET},
+        tests::tester::VmTesterBuilder,
+        HistoryDisabled,
+    },
+};
+
+/// Checks that `TX_GAS_LIMIT_OFFSET` constant is correct.
+#[test]
+fn test_tx_gas_limit_offset() {
+    let mut vm = VmTesterBuilder::new(HistoryDisabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let gas_limit = 9999.into();
+    let tx = vm.rich_accounts[0].get_l2_tx_for_execute(
+        Execute::default(),
+        Some(Fee {
+            gas_limit,
+            ..Account::default_fee()
+        }),
+    );
+
+    vm.vm.push_transaction(tx);
+
+    let gas_limit_from_memory = vm
+        .vm
+        .state
+        .memory
+        .read_slot(
+            BOOTLOADER_HEAP_PAGE as usize,
+            TX_DESCRIPTION_OFFSET + TX_GAS_LIMIT_OFFSET,
+        )
+        .value;
+    assert_eq!(gas_limit_from_memory, gas_limit);
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/get_used_contracts.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/get_used_contracts.rs
@@ -1,0 +1,158 @@
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
+
+use itertools::Itertools;
+use zk_evm_1_5_0::{
+    abstractions::DecommittmentProcessor,
+    aux_structures::{DecommittmentQuery, MemoryPage, Timestamp},
+    zkevm_opcode_defs::{VersionedHashHeader, VersionedHashNormalizedPreimage},
+};
+use zksync_state::WriteStorage;
+use zksync_system_constants::CONTRACT_DEPLOYER_ADDRESS;
+use zksync_test_account::Account;
+use zksync_types::{Execute, U256};
+use zksync_utils::{bytecode::hash_bytecode, h256_to_u256};
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{TxType, VmTesterBuilder},
+            utils::{read_test_contract, BASE_SYSTEM_CONTRACTS},
+        },
+        HistoryDisabled, Vm,
+    },
+    HistoryMode,
+};
+
+#[test]
+fn test_get_used_contracts() {
+    let mut vm = VmTesterBuilder::new(HistoryDisabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .build();
+
+    assert!(known_bytecodes_without_aa_code(&vm.vm).is_empty());
+
+    // create and push and execute some not-empty factory deps transaction with success status
+    // to check that `get_used_contracts()` updates
+    let contract_code = read_test_contract();
+    let mut account = Account::random();
+    let tx = account.get_deploy_tx(&contract_code, None, TxType::L1 { serial_id: 0 });
+    vm.vm.push_transaction(tx.tx.clone());
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed());
+
+    assert!(vm
+        .vm
+        .get_used_contracts()
+        .contains(&h256_to_u256(tx.bytecode_hash)));
+
+    // Note: `Default_AA` will be in the list of used contracts if L2 tx is used
+    assert_eq!(
+        vm.vm
+            .get_used_contracts()
+            .into_iter()
+            .collect::<HashSet<U256>>(),
+        known_bytecodes_without_aa_code(&vm.vm)
+            .keys()
+            .cloned()
+            .collect::<HashSet<U256>>()
+    );
+
+    // create push and execute some non-empty factory deps transaction that fails
+    // (`known_bytecodes` will be updated but we expect `get_used_contracts()` to not be updated)
+
+    let calldata = [1, 2, 3];
+    let big_calldata: Vec<u8> = calldata
+        .iter()
+        .cycle()
+        .take(calldata.len() * 1024)
+        .cloned()
+        .collect();
+    let account2 = Account::random();
+    let tx2 = account2.get_l1_tx(
+        Execute {
+            contract_address: CONTRACT_DEPLOYER_ADDRESS,
+            calldata: big_calldata,
+            value: Default::default(),
+            factory_deps: vec![vec![1; 32]],
+        },
+        1,
+    );
+
+    vm.vm.push_transaction(tx2.clone());
+
+    let res2 = vm.vm.execute(VmExecutionMode::OneTx);
+
+    assert!(res2.result.is_failed());
+
+    for factory_dep in tx2.execute.factory_deps {
+        let hash = hash_bytecode(&factory_dep);
+        let hash_to_u256 = h256_to_u256(hash);
+        assert!(known_bytecodes_without_aa_code(&vm.vm)
+            .keys()
+            .contains(&hash_to_u256));
+        assert!(!vm.vm.get_used_contracts().contains(&hash_to_u256));
+    }
+}
+
+#[test]
+fn test_contract_is_used_right_after_prepare_to_decommit() {
+    let mut vm = VmTesterBuilder::new(HistoryDisabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .build();
+
+    assert!(vm.vm.get_used_contracts().is_empty());
+
+    let bytecode_hash =
+        U256::from_str("0x100067ff3124f394104ab03481f7923f0bc4029a2aa9d41cc1d848c81257185")
+            .unwrap();
+    vm.vm
+        .state
+        .decommittment_processor
+        .populate(vec![(bytecode_hash, vec![])], Timestamp(0));
+
+    let header = hex::decode("0100067f").unwrap();
+    let normalized_preimage =
+        hex::decode("f3124f394104ab03481f7923f0bc4029a2aa9d41cc1d848c81257185").unwrap();
+    vm.vm
+        .state
+        .decommittment_processor
+        .prepare_to_decommit(
+            0,
+            DecommittmentQuery {
+                header: VersionedHashHeader(header.try_into().unwrap()),
+                normalized_preimage: VersionedHashNormalizedPreimage(
+                    normalized_preimage.try_into().unwrap(),
+                ),
+                timestamp: Timestamp(0),
+                memory_page: MemoryPage(0),
+                decommitted_length: 0,
+                is_fresh: false,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(vm.vm.get_used_contracts(), vec![bytecode_hash]);
+}
+
+fn known_bytecodes_without_aa_code<S: WriteStorage, H: HistoryMode>(
+    vm: &Vm<S, H>,
+) -> HashMap<U256, Vec<U256>> {
+    let mut known_bytecodes_without_aa_code = vm
+        .state
+        .decommittment_processor
+        .known_bytecodes
+        .inner()
+        .clone();
+
+    known_bytecodes_without_aa_code
+        .remove(&h256_to_u256(BASE_SYSTEM_CONTRACTS.default_aa.hash))
+        .unwrap();
+
+    known_bytecodes_without_aa_code
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/invalid_bytecode.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/invalid_bytecode.rs
@@ -1,0 +1,120 @@
+use zksync_types::H256;
+use zksync_utils::h256_to_u256;
+
+use crate::vm_latest::tests::tester::VmTesterBuilder;
+use crate::vm_latest::types::inputs::system_env::TxExecutionMode;
+use crate::vm_latest::{HistoryEnabled, TxRevertReason};
+
+// TODO this test requires a lot of hacks for bypassing the bytecode checks in the VM.
+// Port it later, it's not significant. for now
+
+#[test]
+fn test_invalid_bytecode() {
+    let mut vm_builder = VmTesterBuilder::new(HistoryEnabled)
+        .with_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1);
+    let mut storage = vm_builder.take_storage();
+    let mut vm = vm_builder.build(&mut storage);
+
+    let block_gas_per_pubdata = vm_test_env
+        .block_context
+        .context
+        .block_gas_price_per_pubdata();
+
+    let mut test_vm_with_custom_bytecode_hash =
+        |bytecode_hash: H256, expected_revert_reason: Option<TxRevertReason>| {
+            let mut oracle_tools =
+                OracleTools::new(vm_test_env.storage_ptr.as_mut(), HistoryEnabled);
+
+            let (encoded_tx, predefined_overhead) = get_l1_tx_with_custom_bytecode_hash(
+                h256_to_u256(bytecode_hash),
+                block_gas_per_pubdata as u32,
+            );
+
+            run_vm_with_custom_factory_deps(
+                &mut oracle_tools,
+                vm_test_env.block_context.context,
+                &vm_test_env.block_properties,
+                encoded_tx,
+                predefined_overhead,
+                expected_revert_reason,
+            );
+        };
+
+    let failed_to_mark_factory_deps = |msg: &str, data: Vec<u8>| {
+        TxRevertReason::FailedToMarkFactoryDependencies(VmRevertReason::General {
+            msg: msg.to_string(),
+            data,
+        })
+    };
+
+    // Here we provide the correctly-formatted bytecode hash of
+    // odd length, so it should work.
+    test_vm_with_custom_bytecode_hash(
+        H256([
+            1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ]),
+        None,
+    );
+
+    // Here we provide correctly formatted bytecode of even length, so
+    // it should fail.
+    test_vm_with_custom_bytecode_hash(
+        H256([
+            1, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ]),
+        Some(failed_to_mark_factory_deps(
+            "Code length in words must be odd",
+            vec![
+                8, 195, 121, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 67, 111, 100, 101, 32, 108, 101, 110,
+                103, 116, 104, 32, 105, 110, 32, 119, 111, 114, 100, 115, 32, 109, 117, 115, 116,
+                32, 98, 101, 32, 111, 100, 100,
+            ],
+        )),
+    );
+
+    // Here we provide incorrectly formatted bytecode of odd length, so
+    // it should fail.
+    test_vm_with_custom_bytecode_hash(
+        H256([
+            1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ]),
+        Some(failed_to_mark_factory_deps(
+            "Incorrectly formatted bytecodeHash",
+            vec![
+                8, 195, 121, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 34, 73, 110, 99, 111, 114, 114, 101, 99,
+                116, 108, 121, 32, 102, 111, 114, 109, 97, 116, 116, 101, 100, 32, 98, 121, 116,
+                101, 99, 111, 100, 101, 72, 97, 115, 104, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
+        )),
+    );
+
+    // Here we provide incorrectly formatted bytecode of odd length, so
+    // it should fail.
+    test_vm_with_custom_bytecode_hash(
+        H256([
+            2, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ]),
+        Some(failed_to_mark_factory_deps(
+            "Incorrectly formatted bytecodeHash",
+            vec![
+                8, 195, 121, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 34, 73, 110, 99, 111, 114, 114, 101, 99,
+                116, 108, 121, 32, 102, 111, 114, 109, 97, 116, 116, 101, 100, 32, 98, 121, 116,
+                101, 99, 111, 100, 101, 72, 97, 115, 104, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
+        )),
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/is_write_initial.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/is_write_initial.rs
@@ -1,0 +1,48 @@
+use zksync_state::ReadStorage;
+use zksync_types::get_nonce_key;
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{Account, TxType, VmTesterBuilder},
+            utils::read_test_contract,
+        },
+        HistoryDisabled,
+    },
+};
+
+#[test]
+fn test_is_write_initial_behaviour() {
+    // In this test, we check result of `is_write_initial` at different stages.
+    // The main idea is to check that `is_write_initial` storage uses the correct cache for initial_writes and doesn't
+    // messed up it with the repeated writes during the one batch execution.
+
+    let mut account = Account::random();
+    let mut vm = VmTesterBuilder::new(HistoryDisabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_rich_accounts(vec![account.clone()])
+        .build();
+
+    let nonce_key = get_nonce_key(&account.address);
+    // Check that the next write to the nonce key will be initial.
+    assert!(vm
+        .storage
+        .as_ref()
+        .borrow_mut()
+        .is_write_initial(&nonce_key));
+
+    let contract_code = read_test_contract();
+    let tx = account.get_deploy_tx(&contract_code, None, TxType::L2).tx;
+
+    vm.vm.push_transaction(tx);
+    vm.vm.execute(VmExecutionMode::OneTx);
+
+    // Check that `is_write_initial` still returns true for the nonce key.
+    assert!(vm
+        .storage
+        .as_ref()
+        .borrow_mut()
+        .is_write_initial(&nonce_key));
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/l1_tx_execution.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/l1_tx_execution.rs
@@ -1,0 +1,193 @@
+use ethabi::Token;
+use zksync_contracts::l1_messenger_contract;
+use zksync_system_constants::{BOOTLOADER_ADDRESS, L1_MESSENGER_ADDRESS};
+use zksync_types::{
+    get_code_key, get_known_code_key,
+    l2_to_l1_log::{L2ToL1Log, UserL2ToL1Log},
+    storage_writes_deduplicator::StorageWritesDeduplicator,
+    Execute, ExecuteTransactionCommon, U256,
+};
+use zksync_utils::u256_to_h256;
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{TxType, VmTesterBuilder},
+            utils::{read_test_contract, verify_required_storage, BASE_SYSTEM_CONTRACTS},
+        },
+        types::internals::TransactionData,
+        HistoryEnabled,
+    },
+};
+
+#[test]
+fn test_l1_tx_execution() {
+    // In this test, we try to execute a contract deployment from L1
+    // Here instead of marking code hash via the bootloader means, we will be
+    // using L1->L2 communication, the same it would likely be done during the priority mode.
+
+    // There are always at least 9 initial writes here, because we pay fees from l1:
+    // - `totalSupply` of ETH token
+    // - balance of the refund recipient
+    // - balance of the bootloader
+    // - `tx_rolling` hash
+    // - `gasPerPubdataByte`
+    // - `basePubdataSpent`
+    // - rolling hash of L2->L1 logs
+    // - transaction number in block counter
+    // - L2->L1 log counter in `L1Messenger`
+
+    // TODO(PLA-537): right now we are using 5 slots instead of 9 due to 0 fee for transaction.
+    let basic_initial_writes = 5;
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_base_system_smart_contracts(BASE_SYSTEM_CONTRACTS.clone())
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let contract_code = read_test_contract();
+    let account = &mut vm.rich_accounts[0];
+    let deploy_tx = account.get_deploy_tx(&contract_code, None, TxType::L1 { serial_id: 1 });
+    let tx_data: TransactionData = deploy_tx.tx.clone().into();
+
+    let required_l2_to_l1_logs: Vec<_> = vec![L2ToL1Log {
+        shard_id: 0,
+        is_service: true,
+        tx_number_in_block: 0,
+        sender: BOOTLOADER_ADDRESS,
+        key: tx_data.tx_hash(0.into()),
+        value: u256_to_h256(U256::from(1u32)),
+    }]
+    .into_iter()
+    .map(UserL2ToL1Log)
+    .collect();
+
+    vm.vm.push_transaction(deploy_tx.tx.clone());
+
+    let res = vm.vm.execute(VmExecutionMode::OneTx);
+
+    // The code hash of the deployed contract should be marked as republished.
+    let known_codes_key = get_known_code_key(&deploy_tx.bytecode_hash);
+
+    // The contract should be deployed successfully.
+    let account_code_key = get_code_key(&deploy_tx.address);
+
+    let expected_slots = vec![
+        (u256_to_h256(U256::from(1u32)), known_codes_key),
+        (deploy_tx.bytecode_hash, account_code_key),
+    ];
+    assert!(!res.result.is_failed());
+
+    verify_required_storage(&vm.vm.state, expected_slots);
+
+    assert_eq!(res.logs.user_l2_to_l1_logs, required_l2_to_l1_logs);
+
+    let tx = account.get_test_contract_transaction(
+        deploy_tx.address,
+        true,
+        None,
+        false,
+        TxType::L1 { serial_id: 0 },
+    );
+    vm.vm.push_transaction(tx);
+    let res = vm.vm.execute(VmExecutionMode::OneTx);
+    let storage_logs = res.logs.storage_logs;
+    let res = StorageWritesDeduplicator::apply_on_empty_state(&storage_logs);
+
+    // Tx panicked
+    assert_eq!(res.initial_storage_writes, basic_initial_writes);
+
+    let tx = account.get_test_contract_transaction(
+        deploy_tx.address,
+        false,
+        None,
+        false,
+        TxType::L1 { serial_id: 0 },
+    );
+    vm.vm.push_transaction(tx.clone());
+    let res = vm.vm.execute(VmExecutionMode::OneTx);
+    let storage_logs = res.logs.storage_logs;
+    let res = StorageWritesDeduplicator::apply_on_empty_state(&storage_logs);
+    // We changed one slot inside contract. However, the rewrite of the `basePubdataSpent` didn't happen, since it was the same
+    // as the start of the previous tx. Thus we have `+1` slot for the changed counter and `-1` slot for base pubdata spent
+    assert_eq!(res.initial_storage_writes - basic_initial_writes, 0);
+
+    // No repeated writes
+    let repeated_writes = res.repeated_storage_writes;
+    assert_eq!(res.repeated_storage_writes, 0);
+
+    vm.vm.push_transaction(tx);
+    let storage_logs = vm.vm.execute(VmExecutionMode::OneTx).logs.storage_logs;
+    let res = StorageWritesDeduplicator::apply_on_empty_state(&storage_logs);
+    // We do the same storage write, it will be deduplicated, so still 4 initial write and 0 repeated.
+    // But now the base pubdata spent has changed too.
+    assert_eq!(res.initial_storage_writes - basic_initial_writes, 1);
+    assert_eq!(res.repeated_storage_writes, repeated_writes);
+
+    let tx = account.get_test_contract_transaction(
+        deploy_tx.address,
+        false,
+        Some(10.into()),
+        false,
+        TxType::L1 { serial_id: 1 },
+    );
+    vm.vm.push_transaction(tx);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    // Method is not payable tx should fail
+    assert!(result.result.is_failed(), "The transaction should fail");
+
+    let res = StorageWritesDeduplicator::apply_on_empty_state(&result.logs.storage_logs);
+    // There are only basic initial writes
+    assert_eq!(res.initial_storage_writes - basic_initial_writes, 1);
+}
+
+#[test]
+fn test_l1_tx_execution_high_gas_limit() {
+    // In this test, we try to execute an L1->L2 transaction with a high gas limit.
+    // Usually priority transactions with dangerously gas limit should even pass the checks on the L1,
+    // however, they might pass during the transition period to the new fee model, so we check that we can safely process those.
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_base_system_smart_contracts(BASE_SYSTEM_CONTRACTS.clone())
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let account = &mut vm.rich_accounts[0];
+
+    let l1_messenger = l1_messenger_contract();
+
+    let contract_function = l1_messenger.function("sendToL1").unwrap();
+    let params = [
+        // Even a message of size 100k should not be able to be sent by a priority transaction
+        Token::Bytes(vec![0u8; 100_000]),
+    ];
+    let calldata = contract_function.encode_input(&params).unwrap();
+
+    let mut tx = account.get_l1_tx(
+        Execute {
+            contract_address: L1_MESSENGER_ADDRESS,
+            value: 0.into(),
+            factory_deps: vec![],
+            calldata,
+        },
+        0,
+    );
+
+    if let ExecuteTransactionCommon::L1(data) = &mut tx.common_data {
+        // Using some large gas limit
+        data.gas_limit = 300_000_000.into();
+    } else {
+        unreachable!()
+    };
+
+    vm.vm.push_transaction(tx);
+
+    let res = vm.vm.execute(VmExecutionMode::OneTx);
+
+    assert!(res.result.is_failed(), "The transaction should've failed");
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/l2_blocks.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/l2_blocks.rs
@@ -1,0 +1,431 @@
+//!
+//! Tests for the bootloader
+//! The description for each of the tests can be found in the corresponding `.yul` file.
+//!
+
+use zk_evm_1_5_0::aux_structures::Timestamp;
+use zksync_state::WriteStorage;
+use zksync_system_constants::REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE;
+use zksync_types::{
+    block::{pack_block_info, L2BlockHasher},
+    AccountTreeId, Execute, ExecuteTransactionCommon, L1BatchNumber, L1TxCommonData, L2BlockNumber,
+    ProtocolVersionId, StorageKey, Transaction, H160, H256, SYSTEM_CONTEXT_ADDRESS,
+    SYSTEM_CONTEXT_BLOCK_INFO_POSITION, SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
+    SYSTEM_CONTEXT_CURRENT_TX_ROLLING_HASH_POSITION, U256,
+};
+use zksync_utils::{h256_to_u256, u256_to_h256};
+
+use crate::{
+    interface::{ExecutionResult, Halt, L2BlockEnv, TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        constants::{
+            BOOTLOADER_HEAP_PAGE, TX_OPERATOR_L2_BLOCK_INFO_OFFSET,
+            TX_OPERATOR_SLOTS_PER_L2_BLOCK_INFO,
+        },
+        tests::tester::{default_l1_batch, VmTesterBuilder},
+        utils::l2_blocks::get_l2_block_hash_key,
+        HistoryEnabled, Vm,
+    },
+    HistoryMode,
+};
+
+fn get_l1_noop() -> Transaction {
+    Transaction {
+        common_data: ExecuteTransactionCommon::L1(L1TxCommonData {
+            sender: H160::random(),
+            gas_limit: U256::from(2000000u32),
+            gas_per_pubdata_limit: REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE.into(),
+            ..Default::default()
+        }),
+        execute: Execute::default(),
+        received_timestamp_ms: 0,
+        raw_bytes: None,
+    }
+}
+
+#[test]
+fn test_l2_block_initialization_timestamp() {
+    // This test checks that the L2 block initialization works correctly.
+    // Here we check that that the first block must have timestamp that is greater or equal to the timestamp
+    // of the current batch.
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    // Override the timestamp of the current miniblock to be 0.
+    vm.vm.bootloader_state.push_l2_block(L2BlockEnv {
+        number: 1,
+        timestamp: 0,
+        prev_block_hash: L2BlockHasher::legacy_hash(L2BlockNumber(0)),
+        max_virtual_blocks_to_create: 1,
+    });
+    let l1_tx = get_l1_noop();
+
+    vm.vm.push_transaction(l1_tx);
+    let res = vm.vm.execute(VmExecutionMode::OneTx);
+
+    assert_eq!(
+        res.result,
+        ExecutionResult::Halt {reason: Halt::FailedToSetL2Block("The timestamp of the L2 block must be greater than or equal to the timestamp of the current batch".to_string())}
+    );
+}
+
+#[test]
+fn test_l2_block_initialization_number_non_zero() {
+    // This test checks that the L2 block initialization works correctly.
+    // Here we check that the first miniblock number can not be zero.
+
+    let l1_batch = default_l1_batch(L1BatchNumber(1));
+    let first_l2_block = L2BlockEnv {
+        number: 0,
+        timestamp: l1_batch.timestamp,
+        prev_block_hash: L2BlockHasher::legacy_hash(L2BlockNumber(0)),
+        max_virtual_blocks_to_create: 1,
+    };
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_l1_batch_env(l1_batch)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let l1_tx = get_l1_noop();
+
+    vm.vm.push_transaction(l1_tx);
+
+    let timestamp = Timestamp(vm.vm.state.local_state.timestamp);
+    set_manual_l2_block_info(&mut vm.vm, 0, first_l2_block, timestamp);
+
+    let res = vm.vm.execute(VmExecutionMode::OneTx);
+
+    assert_eq!(
+        res.result,
+        ExecutionResult::Halt {
+            reason: Halt::FailedToSetL2Block(
+                "L2 block number is never expected to be zero".to_string()
+            )
+        }
+    );
+}
+
+fn test_same_l2_block(
+    expected_error: Option<Halt>,
+    override_timestamp: Option<u64>,
+    override_prev_block_hash: Option<H256>,
+) {
+    let mut l1_batch = default_l1_batch(L1BatchNumber(1));
+    l1_batch.timestamp = 1;
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_l1_batch_env(l1_batch)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let l1_tx = get_l1_noop();
+    vm.vm.push_transaction(l1_tx.clone());
+    let res = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!res.result.is_failed());
+
+    let mut current_l2_block = vm.vm.batch_env.first_l2_block;
+
+    if let Some(timestamp) = override_timestamp {
+        current_l2_block.timestamp = timestamp;
+    }
+    if let Some(prev_block_hash) = override_prev_block_hash {
+        current_l2_block.prev_block_hash = prev_block_hash;
+    }
+
+    if (None, None) == (override_timestamp, override_prev_block_hash) {
+        current_l2_block.max_virtual_blocks_to_create = 0;
+    }
+
+    vm.vm.push_transaction(l1_tx);
+    let timestamp = Timestamp(vm.vm.state.local_state.timestamp);
+    set_manual_l2_block_info(&mut vm.vm, 1, current_l2_block, timestamp);
+
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+
+    if let Some(err) = expected_error {
+        assert_eq!(result.result, ExecutionResult::Halt { reason: err });
+    } else {
+        assert_eq!(result.result, ExecutionResult::Success { output: vec![] });
+    }
+}
+
+#[test]
+fn test_l2_block_same_l2_block() {
+    // This test aims to test the case when there are multiple transactions inside the same L2 block.
+
+    // Case 1: Incorrect timestamp
+    test_same_l2_block(
+        Some(Halt::FailedToSetL2Block(
+            "The timestamp of the same L2 block must be same".to_string(),
+        )),
+        Some(0),
+        None,
+    );
+
+    // Case 2: Incorrect previous block hash
+    test_same_l2_block(
+        Some(Halt::FailedToSetL2Block(
+            "The previous hash of the same L2 block must be same".to_string(),
+        )),
+        None,
+        Some(H256::zero()),
+    );
+
+    // Case 3: Correct continuation of the same L2 block
+    test_same_l2_block(None, None, None);
+}
+
+fn test_new_l2_block(
+    first_l2_block: L2BlockEnv,
+    overriden_second_block_number: Option<u32>,
+    overriden_second_block_timestamp: Option<u64>,
+    overriden_second_block_prev_block_hash: Option<H256>,
+    expected_error: Option<Halt>,
+) {
+    let mut l1_batch = default_l1_batch(L1BatchNumber(1));
+    l1_batch.timestamp = 1;
+    l1_batch.first_l2_block = first_l2_block;
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_l1_batch_env(l1_batch)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let l1_tx = get_l1_noop();
+
+    // Firstly we execute the first transaction
+    vm.vm.push_transaction(l1_tx.clone());
+    vm.vm.execute(VmExecutionMode::OneTx);
+
+    let mut second_l2_block = vm.vm.batch_env.first_l2_block;
+    second_l2_block.number += 1;
+    second_l2_block.timestamp += 1;
+    second_l2_block.prev_block_hash = vm.vm.bootloader_state.last_l2_block().get_hash();
+
+    if let Some(block_number) = overriden_second_block_number {
+        second_l2_block.number = block_number;
+    }
+    if let Some(timestamp) = overriden_second_block_timestamp {
+        second_l2_block.timestamp = timestamp;
+    }
+    if let Some(prev_block_hash) = overriden_second_block_prev_block_hash {
+        second_l2_block.prev_block_hash = prev_block_hash;
+    }
+
+    vm.vm.bootloader_state.push_l2_block(second_l2_block);
+
+    vm.vm.push_transaction(l1_tx);
+
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    if let Some(err) = expected_error {
+        assert_eq!(result.result, ExecutionResult::Halt { reason: err });
+    } else {
+        assert_eq!(result.result, ExecutionResult::Success { output: vec![] });
+    }
+}
+
+#[test]
+fn test_l2_block_new_l2_block() {
+    // This test is aimed to cover potential issue
+
+    let correct_first_block = L2BlockEnv {
+        number: 1,
+        timestamp: 1,
+        prev_block_hash: L2BlockHasher::legacy_hash(L2BlockNumber(0)),
+        max_virtual_blocks_to_create: 1,
+    };
+
+    // Case 1: Block number increasing by more than 1
+    test_new_l2_block(
+        correct_first_block,
+        Some(3),
+        None,
+        None,
+        Some(Halt::FailedToSetL2Block(
+            "Invalid new L2 block number".to_string(),
+        )),
+    );
+
+    // Case 2: Timestamp not increasing
+    test_new_l2_block(
+        correct_first_block,
+        None,
+        Some(1),
+        None,
+        Some(Halt::FailedToSetL2Block("The timestamp of the new L2 block must be greater than the timestamp of the previous L2 block".to_string())),
+    );
+
+    // Case 3: Incorrect previous block hash
+    test_new_l2_block(
+        correct_first_block,
+        None,
+        None,
+        Some(H256::zero()),
+        Some(Halt::FailedToSetL2Block(
+            "The current L2 block hash is incorrect".to_string(),
+        )),
+    );
+
+    // Case 4: Correct new block
+    test_new_l2_block(correct_first_block, None, None, None, None);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn test_first_in_batch(
+    miniblock_timestamp: u64,
+    miniblock_number: u32,
+    pending_txs_hash: H256,
+    batch_timestamp: u64,
+    new_batch_timestamp: u64,
+    batch_number: u32,
+    proposed_block: L2BlockEnv,
+    expected_error: Option<Halt>,
+) {
+    let mut l1_batch = default_l1_batch(L1BatchNumber(1));
+    l1_batch.number += 1;
+    l1_batch.timestamp = new_batch_timestamp;
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_l1_batch_env(l1_batch)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+    let l1_tx = get_l1_noop();
+
+    // Setting the values provided.
+    let storage_ptr = vm.vm.state.storage.storage.get_ptr();
+    let miniblock_info_slot = StorageKey::new(
+        AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
+        SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
+    );
+    let pending_txs_hash_slot = StorageKey::new(
+        AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
+        SYSTEM_CONTEXT_CURRENT_TX_ROLLING_HASH_POSITION,
+    );
+    let batch_info_slot = StorageKey::new(
+        AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
+        SYSTEM_CONTEXT_BLOCK_INFO_POSITION,
+    );
+    let prev_block_hash_position = get_l2_block_hash_key(miniblock_number - 1);
+
+    storage_ptr.borrow_mut().set_value(
+        miniblock_info_slot,
+        u256_to_h256(pack_block_info(
+            miniblock_number as u64,
+            miniblock_timestamp,
+        )),
+    );
+    storage_ptr
+        .borrow_mut()
+        .set_value(pending_txs_hash_slot, pending_txs_hash);
+    storage_ptr.borrow_mut().set_value(
+        batch_info_slot,
+        u256_to_h256(pack_block_info(batch_number as u64, batch_timestamp)),
+    );
+    storage_ptr.borrow_mut().set_value(
+        prev_block_hash_position,
+        L2BlockHasher::legacy_hash(L2BlockNumber(miniblock_number - 1)),
+    );
+
+    // In order to skip checks from the Rust side of the VM, we firstly use some definitely correct L2 block info.
+    // And then override it with the user-provided value
+
+    let last_l2_block = vm.vm.bootloader_state.last_l2_block();
+    let new_l2_block = L2BlockEnv {
+        number: last_l2_block.number + 1,
+        timestamp: last_l2_block.timestamp + 1,
+        prev_block_hash: last_l2_block.get_hash(),
+        max_virtual_blocks_to_create: last_l2_block.max_virtual_blocks_to_create,
+    };
+
+    vm.vm.bootloader_state.push_l2_block(new_l2_block);
+    vm.vm.push_transaction(l1_tx);
+    let timestamp = Timestamp(vm.vm.state.local_state.timestamp);
+    set_manual_l2_block_info(&mut vm.vm, 0, proposed_block, timestamp);
+
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    if let Some(err) = expected_error {
+        assert_eq!(result.result, ExecutionResult::Halt { reason: err });
+    } else {
+        assert_eq!(result.result, ExecutionResult::Success { output: vec![] });
+    }
+}
+
+#[test]
+fn test_l2_block_first_in_batch() {
+    let prev_block_hash = L2BlockHasher::legacy_hash(L2BlockNumber(0));
+    let prev_block_hash = L2BlockHasher::new(L2BlockNumber(1), 1, prev_block_hash)
+        .finalize(ProtocolVersionId::latest());
+    test_first_in_batch(
+        1,
+        1,
+        H256::zero(),
+        1,
+        2,
+        1,
+        L2BlockEnv {
+            number: 2,
+            timestamp: 2,
+            prev_block_hash,
+            max_virtual_blocks_to_create: 1,
+        },
+        None,
+    );
+
+    let prev_block_hash = L2BlockHasher::legacy_hash(L2BlockNumber(0));
+    let prev_block_hash = L2BlockHasher::new(L2BlockNumber(1), 8, prev_block_hash)
+        .finalize(ProtocolVersionId::latest());
+    test_first_in_batch(
+        8,
+        1,
+        H256::zero(),
+        5,
+        12,
+        1,
+        L2BlockEnv {
+            number: 2,
+            timestamp: 9,
+            prev_block_hash,
+            max_virtual_blocks_to_create: 1,
+        },
+        Some(Halt::FailedToSetL2Block("The timestamp of the L2 block must be greater than or equal to the timestamp of the current batch".to_string())),
+    );
+}
+
+fn set_manual_l2_block_info<S: WriteStorage, H: HistoryMode>(
+    vm: &mut Vm<S, H>,
+    tx_number: usize,
+    block_info: L2BlockEnv,
+    timestamp: Timestamp,
+) {
+    let fictive_miniblock_position =
+        TX_OPERATOR_L2_BLOCK_INFO_OFFSET + TX_OPERATOR_SLOTS_PER_L2_BLOCK_INFO * tx_number;
+
+    vm.state.memory.populate_page(
+        BOOTLOADER_HEAP_PAGE as usize,
+        vec![
+            (fictive_miniblock_position, block_info.number.into()),
+            (fictive_miniblock_position + 1, block_info.timestamp.into()),
+            (
+                fictive_miniblock_position + 2,
+                h256_to_u256(block_info.prev_block_hash),
+            ),
+            (
+                fictive_miniblock_position + 3,
+                block_info.max_virtual_blocks_to_create.into(),
+            ),
+        ],
+        timestamp,
+    )
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/migration.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/migration.rs
@@ -1,0 +1,51 @@
+use zksync_types::{get_code_key, H256, SYSTEM_CONTEXT_ADDRESS};
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{get_empty_storage, DeployContractsTx, TxType, VmTesterBuilder},
+            utils::read_test_contract,
+        },
+        HistoryEnabled,
+    },
+};
+
+/// This test checks that the new bootloader will work fine even if the previous system context contract is not
+/// compatible with it, i.e. the bootloader will upgrade it before starting any transaction.
+#[test]
+fn test_migration_for_system_context_aa_interaction() {
+    let mut storage = get_empty_storage();
+    // We will set the system context bytecode to zero.
+    storage.set_value(get_code_key(&SYSTEM_CONTEXT_ADDRESS), H256::zero());
+
+    // In this test, we aim to test whether a simple account interaction (without any fee logic)
+    // will work. The account will try to deploy a simple contract from integration tests.
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_storage(storage)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    // Now, we will just proceed with standard transaction execution.
+    // The bootloader should be able to update system context regardless of whether
+    // the upgrade transaction is there or not.
+    let account = &mut vm.rich_accounts[0];
+    let counter = read_test_contract();
+    let DeployContractsTx { tx, .. } = account.get_deploy_tx(&counter, None, TxType::L2);
+
+    vm.vm.push_transaction(tx);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(
+        !result.result.is_failed(),
+        "Transaction wasn't successful {:#?}",
+        result.result
+    );
+
+    let batch_result = vm.vm.execute(VmExecutionMode::Batch);
+    assert!(
+        !batch_result.result.is_failed(),
+        "Batch transaction wasn't successful {:#?}",
+        batch_result.result
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/mod.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/mod.rs
@@ -1,0 +1,30 @@
+mod bootloader;
+mod default_aa;
+// TODO - fix this test
+// `mod invalid_bytecode;`
+mod block_tip;
+mod bytecode_publishing;
+mod call_tracer;
+mod circuits;
+mod code_oracle;
+mod constants;
+mod gas_limit;
+mod get_used_contracts;
+mod is_write_initial;
+mod l1_tx_execution;
+mod l2_blocks;
+mod migration;
+mod nonce_holder;
+mod precompiles;
+mod prestate_tracer;
+mod refunds;
+mod require_eip712;
+mod rollbacks;
+mod sekp256r1;
+mod simple_execution;
+mod storage;
+mod tester;
+mod tracing_execution_error;
+mod transfer;
+mod upgrade;
+mod utils;

--- a/core/lib/multivm/src/versions/era_vm/tests/nonce_holder.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/nonce_holder.rs
@@ -1,0 +1,188 @@
+use zksync_types::{Execute, Nonce};
+
+use crate::{
+    interface::{
+        ExecutionResult, Halt, TxExecutionMode, TxRevertReason, VmExecutionMode, VmInterface,
+        VmRevertReason,
+    },
+    vm_latest::{
+        tests::{
+            tester::{Account, VmTesterBuilder},
+            utils::read_nonce_holder_tester,
+        },
+        types::internals::TransactionData,
+        HistoryEnabled,
+    },
+};
+
+pub enum NonceHolderTestMode {
+    SetValueUnderNonce,
+    IncreaseMinNonceBy5,
+    IncreaseMinNonceTooMuch,
+    LeaveNonceUnused,
+    IncreaseMinNonceBy1,
+    SwitchToArbitraryOrdering,
+}
+
+impl From<NonceHolderTestMode> for u8 {
+    fn from(mode: NonceHolderTestMode) -> u8 {
+        match mode {
+            NonceHolderTestMode::SetValueUnderNonce => 0,
+            NonceHolderTestMode::IncreaseMinNonceBy5 => 1,
+            NonceHolderTestMode::IncreaseMinNonceTooMuch => 2,
+            NonceHolderTestMode::LeaveNonceUnused => 3,
+            NonceHolderTestMode::IncreaseMinNonceBy1 => 4,
+            NonceHolderTestMode::SwitchToArbitraryOrdering => 5,
+        }
+    }
+}
+
+#[test]
+fn test_nonce_holder() {
+    let mut account = Account::random();
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_deployer()
+        .with_custom_contracts(vec![(
+            read_nonce_holder_tester().to_vec(),
+            account.address,
+            true,
+        )])
+        .with_rich_accounts(vec![account.clone()])
+        .build();
+
+    let mut run_nonce_test = |nonce: u32,
+                              test_mode: NonceHolderTestMode,
+                              error_message: Option<String>,
+                              comment: &'static str| {
+        // In this test we have to reset VM state after each test case. Because once bootloader failed during the validation of the transaction,
+        // it will fail again and again. At the same time we have to keep the same storage, because we want to keep the nonce holder contract state.
+        // The easiest way in terms of lifetimes is to reuse `vm_builder` to achieve it.
+        vm.reset_state(true);
+        let mut transaction_data: TransactionData = account
+            .get_l2_tx_for_execute_with_nonce(
+                Execute {
+                    contract_address: account.address,
+                    calldata: vec![12],
+                    value: Default::default(),
+                    factory_deps: vec![],
+                },
+                None,
+                Nonce(nonce),
+            )
+            .into();
+
+        transaction_data.signature = vec![test_mode.into()];
+        vm.vm.push_raw_transaction(transaction_data, 0, 0, true);
+        let result = vm.vm.execute(VmExecutionMode::OneTx);
+
+        if let Some(msg) = error_message {
+            let expected_error =
+                TxRevertReason::Halt(Halt::ValidationFailed(VmRevertReason::General {
+                    msg,
+                    data: vec![],
+                }));
+            let ExecutionResult::Halt { reason } = result.result else {
+                panic!("Expected revert, got {:?}", result.result);
+            };
+            assert_eq!(
+                reason.to_string(),
+                expected_error.to_string(),
+                "{}",
+                comment
+            );
+        } else {
+            assert!(!result.result.is_failed(), "{}", comment);
+        }
+    };
+    // Test 1: trying to set value under non sequential nonce value.
+    run_nonce_test(
+        1u32,
+        NonceHolderTestMode::SetValueUnderNonce,
+        Some("Previous nonce has not been used".to_string()),
+        "Allowed to set value under non sequential value",
+    );
+
+    // Test 2: increase min nonce by 1 with sequential nonce ordering:
+    run_nonce_test(
+        0u32,
+        NonceHolderTestMode::IncreaseMinNonceBy1,
+        None,
+        "Failed to increment nonce by 1 for sequential account",
+    );
+
+    // Test 3: correctly set value under nonce with sequential nonce ordering:
+    run_nonce_test(
+        1u32,
+        NonceHolderTestMode::SetValueUnderNonce,
+        None,
+        "Failed to set value under nonce sequential value",
+    );
+
+    // Test 5: migrate to the arbitrary nonce ordering:
+    run_nonce_test(
+        2u32,
+        NonceHolderTestMode::SwitchToArbitraryOrdering,
+        None,
+        "Failed to switch to arbitrary ordering",
+    );
+
+    // Test 6: increase min nonce by 5
+    run_nonce_test(
+        6u32,
+        NonceHolderTestMode::IncreaseMinNonceBy5,
+        None,
+        "Failed to increase min nonce by 5",
+    );
+
+    // Test 7: since the nonces in range [6,10] are no longer allowed, the
+    // tx with nonce 10 should not be allowed
+    run_nonce_test(
+        10u32,
+        NonceHolderTestMode::IncreaseMinNonceBy5,
+        Some("Reusing the same nonce twice".to_string()),
+        "Allowed to reuse nonce below the minimal one",
+    );
+
+    // Test 8: we should be able to use nonce 13
+    run_nonce_test(
+        13u32,
+        NonceHolderTestMode::SetValueUnderNonce,
+        None,
+        "Did not allow to use unused nonce 10",
+    );
+
+    // Test 9: we should not be able to reuse nonce 13
+    run_nonce_test(
+        13u32,
+        NonceHolderTestMode::IncreaseMinNonceBy5,
+        Some("Reusing the same nonce twice".to_string()),
+        "Allowed to reuse the same nonce twice",
+    );
+
+    // Test 10: we should be able to simply use nonce 14, while bumping the minimal nonce by 5
+    run_nonce_test(
+        14u32,
+        NonceHolderTestMode::IncreaseMinNonceBy5,
+        None,
+        "Did not allow to use a bumped nonce",
+    );
+
+    // Test 11: Do not allow bumping nonce by too much
+    run_nonce_test(
+        16u32,
+        NonceHolderTestMode::IncreaseMinNonceTooMuch,
+        Some("The value for incrementing the nonce is too high".to_string()),
+        "Allowed for incrementing min nonce too much",
+    );
+
+    // Test 12: Do not allow not setting a nonce as used
+    run_nonce_test(
+        16u32,
+        NonceHolderTestMode::LeaveNonceUnused,
+        Some("The nonce was not set as used".to_string()),
+        "Allowed to leave nonce as unused",
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/precompiles.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/precompiles.rs
@@ -1,0 +1,136 @@
+use zk_evm_1_5_0::zk_evm_abstractions::precompiles::PrecompileAddress;
+use zksync_types::{Address, Execute};
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        constants::BATCH_COMPUTATIONAL_GAS_LIMIT,
+        tests::{tester::VmTesterBuilder, utils::read_precompiles_contract},
+        HistoryEnabled,
+    },
+};
+
+#[test]
+fn test_keccak() {
+    // Execute special transaction and check that at least 1000 keccak calls were made.
+    let contract = read_precompiles_contract();
+    let address = Address::random();
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_random_rich_accounts(1)
+        .with_deployer()
+        .with_bootloader_gas_limit(BATCH_COMPUTATIONAL_GAS_LIMIT)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_custom_contracts(vec![(contract, address, true)])
+        .build();
+
+    // calldata for `doKeccak(1000)`.
+    let keccak1000_calldata =
+        "370f20ac00000000000000000000000000000000000000000000000000000000000003e8";
+
+    let account = &mut vm.rich_accounts[0];
+    let tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: address,
+            calldata: hex::decode(keccak1000_calldata).unwrap(),
+            value: Default::default(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+    vm.vm.push_transaction(tx);
+    let _ = vm.vm.inspect(Default::default(), VmExecutionMode::OneTx);
+
+    let keccak_count = vm
+        .vm
+        .state
+        .precompiles_processor
+        .precompile_cycles_history
+        .inner()
+        .iter()
+        .filter(|(precompile, _)| precompile == &PrecompileAddress::Keccak256)
+        .count();
+
+    assert!(keccak_count >= 1000);
+}
+
+#[test]
+fn test_sha256() {
+    // Execute special transaction and check that at least 1000 `sha256` calls were made.
+    let contract = read_precompiles_contract();
+    let address = Address::random();
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_random_rich_accounts(1)
+        .with_deployer()
+        .with_bootloader_gas_limit(BATCH_COMPUTATIONAL_GAS_LIMIT)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_custom_contracts(vec![(contract, address, true)])
+        .build();
+
+    // calldata for `doSha256(1000)`.
+    let sha1000_calldata =
+        "5d0b4fb500000000000000000000000000000000000000000000000000000000000003e8";
+
+    let account = &mut vm.rich_accounts[0];
+    let tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: address,
+            calldata: hex::decode(sha1000_calldata).unwrap(),
+            value: Default::default(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+    vm.vm.push_transaction(tx);
+    let _ = vm.vm.inspect(Default::default(), VmExecutionMode::OneTx);
+
+    let sha_count = vm
+        .vm
+        .state
+        .precompiles_processor
+        .precompile_cycles_history
+        .inner()
+        .iter()
+        .filter(|(precompile, _)| precompile == &PrecompileAddress::SHA256)
+        .count();
+
+    assert!(sha_count >= 1000);
+}
+
+#[test]
+fn test_ecrecover() {
+    // Execute simple transfer and check that exactly 1 `ecrecover` call was made (it's done during tx validation).
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_random_rich_accounts(1)
+        .with_deployer()
+        .with_bootloader_gas_limit(BATCH_COMPUTATIONAL_GAS_LIMIT)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .build();
+
+    let account = &mut vm.rich_accounts[0];
+    let tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: account.address,
+            calldata: Vec::new(),
+            value: Default::default(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+    vm.vm.push_transaction(tx);
+    let _ = vm.vm.inspect(Default::default(), VmExecutionMode::OneTx);
+
+    let ecrecover_count = vm
+        .vm
+        .state
+        .precompiles_processor
+        .precompile_cycles_history
+        .inner()
+        .iter()
+        .filter(|(precompile, _)| precompile == &PrecompileAddress::Ecrecover)
+        .count();
+
+    assert_eq!(ecrecover_count, 1);
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/prestate_tracer.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/prestate_tracer.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+
+use once_cell::sync::OnceCell;
+use zksync_test_account::TxType;
+use zksync_types::{utils::deployed_address_create, Execute, U256};
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    tracers::PrestateTracer,
+    vm_latest::{
+        constants::BATCH_COMPUTATIONAL_GAS_LIMIT,
+        tests::{tester::VmTesterBuilder, utils::read_simple_transfer_contract},
+        HistoryEnabled, ToTracerPointer,
+    },
+};
+
+#[test]
+fn test_prestate_tracer() {
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_random_rich_accounts(1)
+        .with_deployer()
+        .with_bootloader_gas_limit(BATCH_COMPUTATIONAL_GAS_LIMIT)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .build();
+
+    vm.deploy_test_contract();
+    let account = &mut vm.rich_accounts[0];
+
+    let tx1 = account.get_test_contract_transaction(
+        vm.test_contract.unwrap(),
+        false,
+        Default::default(),
+        true,
+        TxType::L2,
+    );
+    vm.vm.push_transaction(tx1);
+
+    let contract_address = vm.test_contract.unwrap();
+    let prestate_tracer_result = Arc::new(OnceCell::default());
+    let prestate_tracer = PrestateTracer::new(false, prestate_tracer_result.clone());
+    let tracer_ptr = prestate_tracer.into_tracer_pointer();
+    vm.vm.inspect(tracer_ptr.into(), VmExecutionMode::Batch);
+
+    let prestate_result = Arc::try_unwrap(prestate_tracer_result)
+        .unwrap()
+        .take()
+        .unwrap_or_default();
+
+    assert!(prestate_result.1.contains_key(&contract_address));
+}
+
+#[test]
+fn test_prestate_tracer_diff_mode() {
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_random_rich_accounts(1)
+        .with_deployer()
+        .with_bootloader_gas_limit(BATCH_COMPUTATIONAL_GAS_LIMIT)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .build();
+    let contract = read_simple_transfer_contract();
+    let tx = vm
+        .deployer
+        .as_mut()
+        .expect("You have to initialize builder with deployer")
+        .get_deploy_tx(&contract, None, TxType::L2)
+        .tx;
+    let nonce = tx.nonce().unwrap().0.into();
+    vm.vm.push_transaction(tx);
+    vm.vm.execute(VmExecutionMode::OneTx);
+    let deployed_address = deployed_address_create(vm.deployer.as_ref().unwrap().address, nonce);
+    vm.test_contract = Some(deployed_address);
+
+    // Deploy a second copy of the contract to see its appearance in the pre-state
+    let tx2 = vm
+        .deployer
+        .as_mut()
+        .expect("You have to initialize builder with deployer")
+        .get_deploy_tx(&contract, None, TxType::L2)
+        .tx;
+    let nonce2 = tx2.nonce().unwrap().0.into();
+    vm.vm.push_transaction(tx2);
+    vm.vm.execute(VmExecutionMode::OneTx);
+    let deployed_address2 = deployed_address_create(vm.deployer.as_ref().unwrap().address, nonce2);
+
+    let account = &mut vm.rich_accounts[0];
+
+    //enter ether to contract to see difference in the balance post execution
+    let tx0 = Execute {
+        contract_address: vm.test_contract.unwrap(),
+        calldata: Default::default(),
+        value: U256::from(100000),
+        factory_deps: vec![],
+    };
+
+    vm.vm
+        .push_transaction(account.get_l2_tx_for_execute(tx0.clone(), None));
+
+    let tx1 = Execute {
+        contract_address: deployed_address2,
+        calldata: Default::default(),
+        value: U256::from(200000),
+        factory_deps: vec![],
+    };
+
+    vm.vm
+        .push_transaction(account.get_l2_tx_for_execute(tx1, None));
+    let prestate_tracer_result = Arc::new(OnceCell::default());
+    let prestate_tracer = PrestateTracer::new(true, prestate_tracer_result.clone());
+    let tracer_ptr = prestate_tracer.into_tracer_pointer();
+    vm.vm
+        .inspect(tracer_ptr.into(), VmExecutionMode::Bootloader);
+
+    let prestate_result = Arc::try_unwrap(prestate_tracer_result)
+        .unwrap()
+        .take()
+        .unwrap_or_default();
+
+    //assert that the pre-state contains both deployed contracts with balance zero
+    assert!(prestate_result.0.contains_key(&deployed_address));
+    assert!(prestate_result.0.contains_key(&deployed_address2));
+    assert_eq!(
+        prestate_result.0[&deployed_address].balance,
+        Some(U256::zero())
+    );
+    assert_eq!(
+        prestate_result.0[&deployed_address2].balance,
+        Some(U256::zero())
+    );
+
+    //assert that the post-state contains both deployed contracts with the correct balance
+    assert!(prestate_result.1.contains_key(&deployed_address));
+    assert!(prestate_result.1.contains_key(&deployed_address2));
+    assert_eq!(
+        prestate_result.1[&deployed_address].balance,
+        Some(U256::from(100000))
+    );
+    assert_eq!(
+        prestate_result.1[&deployed_address2].balance,
+        Some(U256::from(200000))
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/refunds.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/refunds.rs
@@ -1,0 +1,166 @@
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{DeployContractsTx, TxType, VmTesterBuilder},
+            utils::read_test_contract,
+        },
+        types::internals::TransactionData,
+        HistoryEnabled,
+    },
+};
+
+#[test]
+fn test_predetermined_refunded_gas() {
+    // In this test, we compare the execution of the bootloader with the predefined
+    // refunded gas and without them
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+    let l1_batch = vm.vm.batch_env.clone();
+
+    let counter = read_test_contract();
+    let account = &mut vm.rich_accounts[0];
+
+    let DeployContractsTx {
+        tx,
+        bytecode_hash: _,
+        address: _,
+    } = account.get_deploy_tx(&counter, None, TxType::L2);
+    vm.vm.push_transaction(tx.clone());
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+
+    assert!(!result.result.is_failed());
+
+    // If the refund provided by the operator or the final refund are the 0
+    // there is no impact of the operator's refund at all and so this test does not
+    // make much sense.
+    assert!(
+        result.refunds.operator_suggested_refund > 0,
+        "The operator's refund is 0"
+    );
+    assert!(result.refunds.gas_refunded > 0, "The final refund is 0");
+
+    let result_without_predefined_refunds = vm.vm.execute(VmExecutionMode::Batch);
+    let mut current_state_without_predefined_refunds = vm.vm.get_current_execution_state();
+    assert!(!result_without_predefined_refunds.result.is_failed(),);
+
+    // Here we want to provide the same refund from the operator and check that it's the correct one.
+    // We execute the whole block without refund tracer, because refund tracer will eventually override the provided refund.
+    // But the overall result should be the same
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_l1_batch_env(l1_batch.clone())
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_rich_accounts(vec![account.clone()])
+        .build();
+
+    let tx: TransactionData = tx.into();
+    // Overhead
+    let overhead = tx.overhead_gas();
+    vm.vm
+        .push_raw_transaction(tx.clone(), overhead, result.refunds.gas_refunded, true);
+
+    let result_with_predefined_refunds = vm.vm.execute(VmExecutionMode::Batch);
+    let mut current_state_with_predefined_refunds = vm.vm.get_current_execution_state();
+
+    assert!(!result_with_predefined_refunds.result.is_failed());
+
+    // We need to sort these lists as those are flattened from HashMaps
+    current_state_with_predefined_refunds
+        .used_contract_hashes
+        .sort();
+    current_state_without_predefined_refunds
+        .used_contract_hashes
+        .sort();
+
+    assert_eq!(
+        current_state_with_predefined_refunds.events,
+        current_state_without_predefined_refunds.events
+    );
+
+    assert_eq!(
+        current_state_with_predefined_refunds.user_l2_to_l1_logs,
+        current_state_without_predefined_refunds.user_l2_to_l1_logs
+    );
+
+    assert_eq!(
+        current_state_with_predefined_refunds.system_logs,
+        current_state_without_predefined_refunds.system_logs
+    );
+
+    assert_eq!(
+        current_state_with_predefined_refunds.deduplicated_storage_logs,
+        current_state_without_predefined_refunds.deduplicated_storage_logs
+    );
+    assert_eq!(
+        current_state_with_predefined_refunds.used_contract_hashes,
+        current_state_without_predefined_refunds.used_contract_hashes
+    );
+
+    // In this test we put the different refund from the operator.
+    // We still can't use the refund tracer, because it will override the refund.
+    // But we can check that the logs and events have changed.
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_l1_batch_env(l1_batch)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_rich_accounts(vec![account.clone()])
+        .build();
+
+    let changed_operator_suggested_refund = result.refunds.gas_refunded + 1000;
+    vm.vm
+        .push_raw_transaction(tx, overhead, changed_operator_suggested_refund, true);
+    let result = vm.vm.execute(VmExecutionMode::Batch);
+    let mut current_state_with_changed_predefined_refunds = vm.vm.get_current_execution_state();
+
+    assert!(!result.result.is_failed());
+    current_state_with_changed_predefined_refunds
+        .used_contract_hashes
+        .sort();
+    current_state_without_predefined_refunds
+        .used_contract_hashes
+        .sort();
+
+    assert_eq!(
+        current_state_with_changed_predefined_refunds.events.len(),
+        current_state_without_predefined_refunds.events.len()
+    );
+
+    assert_ne!(
+        current_state_with_changed_predefined_refunds.events,
+        current_state_without_predefined_refunds.events
+    );
+
+    assert_eq!(
+        current_state_with_changed_predefined_refunds.user_l2_to_l1_logs,
+        current_state_without_predefined_refunds.user_l2_to_l1_logs
+    );
+
+    assert_ne!(
+        current_state_with_changed_predefined_refunds.system_logs,
+        current_state_without_predefined_refunds.system_logs
+    );
+
+    assert_eq!(
+        current_state_with_changed_predefined_refunds
+            .deduplicated_storage_logs
+            .len(),
+        current_state_without_predefined_refunds
+            .deduplicated_storage_logs
+            .len()
+    );
+
+    assert_ne!(
+        current_state_with_changed_predefined_refunds.deduplicated_storage_logs,
+        current_state_without_predefined_refunds.deduplicated_storage_logs
+    );
+    assert_eq!(
+        current_state_with_changed_predefined_refunds.used_contract_hashes,
+        current_state_without_predefined_refunds.used_contract_hashes
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/require_eip712.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/require_eip712.rs
@@ -1,0 +1,167 @@
+use ethabi::Token;
+use zksync_eth_signer::{EthereumSigner, TransactionParameters};
+use zksync_system_constants::L2_BASE_TOKEN_ADDRESS;
+use zksync_types::{
+    fee::Fee, l2::L2Tx, transaction_request::TransactionRequest,
+    utils::storage_key_for_standard_token_balance, AccountTreeId, Address, Eip712Domain, Execute,
+    L2ChainId, Nonce, Transaction, U256,
+};
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{Account, VmTester, VmTesterBuilder},
+            utils::read_many_owners_custom_account_contract,
+        },
+        HistoryDisabled,
+    },
+};
+
+impl VmTester<HistoryDisabled> {
+    pub(crate) fn get_eth_balance(&mut self, address: Address) -> U256 {
+        let key = storage_key_for_standard_token_balance(
+            AccountTreeId::new(L2_BASE_TOKEN_ADDRESS),
+            &address,
+        );
+        self.vm.state.storage.storage.read_from_storage(&key)
+    }
+}
+
+// TODO refactor this test it use too much internal details of the VM
+#[tokio::test]
+/// This test deploys 'buggy' account abstraction code, and then tries accessing it both with legacy
+/// and EIP712 transactions.
+/// Currently we support both, but in the future, we should allow only EIP712 transactions to access the AA accounts.
+async fn test_require_eip712() {
+    // Use 3 accounts:
+    // - `private_address` - EOA account, where we have the key
+    // - `account_address` - AA account, where the contract is deployed
+    // - beneficiary - an EOA account, where we'll try to transfer the tokens.
+    let account_abstraction = Account::random();
+    let mut private_account = Account::random();
+    let beneficiary = Account::random();
+
+    let (bytecode, contract) = read_many_owners_custom_account_contract();
+    let mut vm = VmTesterBuilder::new(HistoryDisabled)
+        .with_empty_in_memory_storage()
+        .with_custom_contracts(vec![(bytecode, account_abstraction.address, true)])
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_rich_accounts(vec![account_abstraction.clone(), private_account.clone()])
+        .build();
+
+    assert_eq!(vm.get_eth_balance(beneficiary.address), U256::from(0));
+
+    let chain_id: u32 = 270;
+
+    // First, let's set the owners of the AA account to the `private_address`.
+    // (so that messages signed by `private_address`, are authorized to act on behalf of the AA account).
+    let set_owners_function = contract.function("setOwners").unwrap();
+    let encoded_input = set_owners_function
+        .encode_input(&[Token::Array(vec![Token::Address(private_account.address)])])
+        .unwrap();
+
+    let tx = private_account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: account_abstraction.address,
+            calldata: encoded_input,
+            value: Default::default(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    vm.vm.push_transaction(tx);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed());
+
+    let private_account_balance = vm.get_eth_balance(private_account.address);
+
+    // And now let's do the transfer from the 'account abstraction' to 'beneficiary' (using 'legacy' transaction).
+    // Normally this would not work - unless the operator is malicious.
+    let aa_raw_tx = TransactionParameters {
+        nonce: U256::from(0),
+        to: Some(beneficiary.address),
+        gas: U256::from(100000000),
+        gas_price: Some(U256::from(10000000)),
+        value: U256::from(888000088),
+        data: vec![],
+        chain_id: 270,
+        transaction_type: None,
+        access_list: None,
+        max_fee_per_gas: U256::from(1000000000),
+        max_priority_fee_per_gas: U256::from(1000000000),
+        max_fee_per_blob_gas: None,
+        blob_versioned_hashes: None,
+    };
+
+    let aa_tx = private_account.sign_legacy_tx(aa_raw_tx).await;
+    let (tx_request, hash) = TransactionRequest::from_bytes(&aa_tx, L2ChainId::from(270)).unwrap();
+
+    let mut l2_tx: L2Tx = L2Tx::from_request(tx_request, 10000).unwrap();
+    l2_tx.set_input(aa_tx, hash);
+    // Pretend that operator is malicious and sets the initiator to the AA account.
+    l2_tx.common_data.initiator_address = account_abstraction.address;
+    let transaction: Transaction = l2_tx.into();
+
+    vm.vm.push_transaction(transaction);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed());
+
+    assert_eq!(
+        vm.get_eth_balance(beneficiary.address),
+        U256::from(888000088)
+    );
+    // Make sure that the tokens were transferred from the AA account.
+    assert_eq!(
+        private_account_balance,
+        vm.get_eth_balance(private_account.address)
+    );
+
+    // // Now send the 'classic' EIP712 transaction
+    let tx_712 = L2Tx::new(
+        beneficiary.address,
+        vec![],
+        Nonce(1),
+        Fee {
+            gas_limit: U256::from(1000000000),
+            max_fee_per_gas: U256::from(1000000000),
+            max_priority_fee_per_gas: U256::from(1000000000),
+            gas_per_pubdata_limit: U256::from(1000000000),
+        },
+        account_abstraction.address,
+        U256::from(28374938),
+        vec![],
+        Default::default(),
+    );
+
+    let mut transaction_request: TransactionRequest = tx_712.into();
+    transaction_request.chain_id = Some(chain_id.into());
+
+    let domain = Eip712Domain::new(L2ChainId::from(chain_id));
+    let signature = private_account
+        .get_pk_signer()
+        .sign_typed_data(&domain, &transaction_request)
+        .await
+        .unwrap();
+    let encoded_tx = transaction_request.get_signed_bytes(&signature).unwrap();
+
+    let (aa_txn_request, aa_hash) =
+        TransactionRequest::from_bytes(&encoded_tx, L2ChainId::from(chain_id)).unwrap();
+
+    let mut l2_tx = L2Tx::from_request(aa_txn_request, 100000).unwrap();
+    l2_tx.set_input(encoded_tx, aa_hash);
+
+    let transaction: Transaction = l2_tx.into();
+    vm.vm.push_transaction(transaction);
+    vm.vm.execute(VmExecutionMode::OneTx);
+
+    assert_eq!(
+        vm.get_eth_balance(beneficiary.address),
+        U256::from(916375026)
+    );
+    assert_eq!(
+        private_account_balance,
+        vm.get_eth_balance(private_account.address)
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/rollbacks.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/rollbacks.rs
@@ -1,0 +1,263 @@
+use ethabi::Token;
+use zksync_contracts::{get_loadnext_contract, test_contracts::LoadnextContractExecutionParams};
+use zksync_state::WriteStorage;
+use zksync_types::{get_nonce_key, Execute, U256};
+
+use crate::{
+    interface::{
+        dyn_tracers::vm_1_5_0::DynTracer,
+        tracer::{TracerExecutionStatus, TracerExecutionStopReason},
+        TxExecutionMode, VmExecutionMode, VmInterface, VmInterfaceHistoryEnabled,
+    },
+    vm_latest::{
+        tests::{
+            tester::{DeployContractsTx, TransactionTestInfo, TxModifier, TxType, VmTesterBuilder},
+            utils::read_test_contract,
+        },
+        types::internals::ZkSyncVmState,
+        BootloaderState, HistoryEnabled, HistoryMode, SimpleMemory, ToTracerPointer, VmTracer,
+    },
+};
+
+#[test]
+fn test_vm_rollbacks() {
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let mut account = vm.rich_accounts[0].clone();
+    let counter = read_test_contract();
+    let tx_0 = account.get_deploy_tx(&counter, None, TxType::L2).tx;
+    let tx_1 = account.get_deploy_tx(&counter, None, TxType::L2).tx;
+    let tx_2 = account.get_deploy_tx(&counter, None, TxType::L2).tx;
+
+    let result_without_rollbacks = vm.execute_and_verify_txs(&vec![
+        TransactionTestInfo::new_processed(tx_0.clone(), false),
+        TransactionTestInfo::new_processed(tx_1.clone(), false),
+        TransactionTestInfo::new_processed(tx_2.clone(), false),
+    ]);
+
+    // reset vm
+    vm.reset_with_empty_storage();
+
+    let result_with_rollbacks = vm.execute_and_verify_txs(&vec![
+        TransactionTestInfo::new_rejected(tx_0.clone(), TxModifier::WrongSignatureLength.into()),
+        TransactionTestInfo::new_rejected(tx_0.clone(), TxModifier::WrongMagicValue.into()),
+        TransactionTestInfo::new_rejected(tx_0.clone(), TxModifier::WrongSignature.into()),
+        // The correct nonce is 0, this tx will fail
+        TransactionTestInfo::new_rejected(tx_2.clone(), TxModifier::WrongNonce.into()),
+        // This tx will succeed
+        TransactionTestInfo::new_processed(tx_0.clone(), false),
+        // The correct nonce is 1, this tx will fail
+        TransactionTestInfo::new_rejected(tx_0.clone(), TxModifier::NonceReused.into()),
+        // The correct nonce is 1, this tx will fail
+        TransactionTestInfo::new_rejected(tx_2.clone(), TxModifier::WrongNonce.into()),
+        // This tx will succeed
+        TransactionTestInfo::new_processed(tx_1, false),
+        // The correct nonce is 2, this tx will fail
+        TransactionTestInfo::new_rejected(tx_0.clone(), TxModifier::NonceReused.into()),
+        // This tx will succeed
+        TransactionTestInfo::new_processed(tx_2.clone(), false),
+        // This tx will fail
+        TransactionTestInfo::new_rejected(tx_2, TxModifier::NonceReused.into()),
+        TransactionTestInfo::new_rejected(tx_0, TxModifier::NonceReused.into()),
+    ]);
+
+    assert_eq!(result_without_rollbacks, result_with_rollbacks);
+}
+
+#[test]
+fn test_vm_loadnext_rollbacks() {
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+    let mut account = vm.rich_accounts[0].clone();
+
+    let loadnext_contract = get_loadnext_contract();
+    let loadnext_constructor_data = &[Token::Uint(U256::from(100))];
+    let DeployContractsTx {
+        tx: loadnext_deploy_tx,
+        address,
+        ..
+    } = account.get_deploy_tx_with_factory_deps(
+        &loadnext_contract.bytecode,
+        Some(loadnext_constructor_data),
+        loadnext_contract.factory_deps.clone(),
+        TxType::L2,
+    );
+
+    let loadnext_tx_1 = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: address,
+            calldata: LoadnextContractExecutionParams {
+                reads: 100,
+                writes: 100,
+                events: 100,
+                hashes: 500,
+                recursive_calls: 10,
+                deploys: 60,
+            }
+            .to_bytes(),
+            value: Default::default(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    let loadnext_tx_2 = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: address,
+            calldata: LoadnextContractExecutionParams {
+                reads: 100,
+                writes: 100,
+                events: 100,
+                hashes: 500,
+                recursive_calls: 10,
+                deploys: 60,
+            }
+            .to_bytes(),
+            value: Default::default(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    let result_without_rollbacks = vm.execute_and_verify_txs(&vec![
+        TransactionTestInfo::new_processed(loadnext_deploy_tx.clone(), false),
+        TransactionTestInfo::new_processed(loadnext_tx_1.clone(), false),
+        TransactionTestInfo::new_processed(loadnext_tx_2.clone(), false),
+    ]);
+
+    // reset vm
+    vm.reset_with_empty_storage();
+
+    let result_with_rollbacks = vm.execute_and_verify_txs(&vec![
+        TransactionTestInfo::new_processed(loadnext_deploy_tx.clone(), false),
+        TransactionTestInfo::new_processed(loadnext_tx_1.clone(), true),
+        TransactionTestInfo::new_rejected(
+            loadnext_deploy_tx.clone(),
+            TxModifier::NonceReused.into(),
+        ),
+        TransactionTestInfo::new_processed(loadnext_tx_1, false),
+        TransactionTestInfo::new_processed(loadnext_tx_2.clone(), true),
+        TransactionTestInfo::new_processed(loadnext_tx_2.clone(), true),
+        TransactionTestInfo::new_rejected(loadnext_deploy_tx, TxModifier::NonceReused.into()),
+        TransactionTestInfo::new_processed(loadnext_tx_2, false),
+    ]);
+
+    assert_eq!(result_without_rollbacks, result_with_rollbacks);
+}
+
+// Testing tracer that does not allow the recursion to go deeper than a certain limit
+struct MaxRecursionTracer {
+    max_recursion_depth: usize,
+}
+
+/// Tracer responsible for calculating the number of storage invocations and
+/// stopping the VM execution if the limit is reached.
+impl<S: WriteStorage, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for MaxRecursionTracer {}
+
+impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for MaxRecursionTracer {
+    fn finish_cycle(
+        &mut self,
+        state: &mut ZkSyncVmState<S, H>,
+        _bootloader_state: &mut BootloaderState,
+    ) -> TracerExecutionStatus {
+        let current_depth = state.local_state.callstack.depth();
+
+        if current_depth > self.max_recursion_depth {
+            TracerExecutionStatus::Stop(TracerExecutionStopReason::Finish)
+        } else {
+            TracerExecutionStatus::Continue
+        }
+    }
+}
+
+#[test]
+fn test_layered_rollback() {
+    // This test checks that the layered rollbacks work correctly, i.e.
+    // the rollback by the operator will always revert all the changes
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let account = &mut vm.rich_accounts[0];
+    let loadnext_contract = get_loadnext_contract().bytecode;
+
+    let DeployContractsTx {
+        tx: deploy_tx,
+        address,
+        ..
+    } = account.get_deploy_tx(
+        &loadnext_contract,
+        Some(&[Token::Uint(0.into())]),
+        TxType::L2,
+    );
+    vm.vm.push_transaction(deploy_tx);
+    let deployment_res = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!deployment_res.result.is_failed(), "transaction failed");
+
+    let loadnext_transaction = account.get_loadnext_transaction(
+        address,
+        LoadnextContractExecutionParams {
+            writes: 1,
+            recursive_calls: 20,
+            ..LoadnextContractExecutionParams::empty()
+        },
+        TxType::L2,
+    );
+
+    let nonce_val = vm
+        .vm
+        .state
+        .storage
+        .storage
+        .read_from_storage(&get_nonce_key(&account.address));
+
+    vm.vm.make_snapshot();
+
+    vm.vm.push_transaction(loadnext_transaction.clone());
+    vm.vm.inspect(
+        MaxRecursionTracer {
+            max_recursion_depth: 15,
+        }
+        .into_tracer_pointer()
+        .into(),
+        VmExecutionMode::OneTx,
+    );
+
+    let nonce_val2 = vm
+        .vm
+        .state
+        .storage
+        .storage
+        .read_from_storage(&get_nonce_key(&account.address));
+
+    // The tracer stopped after the validation has passed, so nonce has already been increased
+    assert_eq!(nonce_val + U256::one(), nonce_val2, "nonce did not change");
+
+    vm.vm.rollback_to_the_latest_snapshot();
+
+    let nonce_val_after_rollback = vm
+        .vm
+        .state
+        .storage
+        .storage
+        .read_from_storage(&get_nonce_key(&account.address));
+
+    assert_eq!(
+        nonce_val, nonce_val_after_rollback,
+        "nonce changed after rollback"
+    );
+
+    vm.vm.push_transaction(loadnext_transaction);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed(), "transaction must not fail");
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/sekp256r1.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/sekp256r1.rs
@@ -1,0 +1,74 @@
+use zk_evm_1_5_0::zkevm_opcode_defs::p256;
+use zksync_system_constants::P256VERIFY_PRECOMPILE_ADDRESS;
+use zksync_types::{web3::keccak256, Execute, H256, U256};
+use zksync_utils::h256_to_u256;
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{tests::tester::VmTesterBuilder, ExecutionResult, HistoryEnabled},
+};
+
+#[test]
+fn test_sekp256r1() {
+    // In this test, we aim to test whether a simple account interaction (without any fee logic)
+    // will work. The account will try to deploy a simple contract from integration tests.
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_execution_mode(TxExecutionMode::EthCall)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let account = &mut vm.rich_accounts[0];
+
+    // The digest, secret key and public key were copied from the following test suit: `https://github.com/hyperledger/besu/blob/b6a6402be90339367d5bcabcd1cfd60df4832465/crypto/algorithms/src/test/java/org/hyperledger/besu/crypto/SECP256R1Test.java#L36`
+    let sk = p256::SecretKey::from_slice(
+        &hex::decode("519b423d715f8b581f4fa8ee59f4771a5b44c8130b4e3eacca54a56dda72b464").unwrap(),
+    )
+    .unwrap();
+    let sk = p256::ecdsa::SigningKey::from(sk);
+
+    let digest = keccak256(&hex::decode("5905238877c77421f73e43ee3da6f2d9e2ccad5fc942dcec0cbd25482935faaf416983fe165b1a045ee2bcd2e6dca3bdf46c4310a7461f9a37960ca672d3feb5473e253605fb1ddfd28065b53cb5858a8ad28175bf9bd386a5e471ea7a65c17cc934a9d791e91491eb3754d03799790fe2d308d16146d5c9b0d0debd97d79ce8").unwrap());
+    let public_key_encoded = hex::decode("1ccbe91c075fc7f4f033bfa248db8fccd3565de94bbfb12f3c59ff46c271bf83ce4014c68811f9a21a1fdb2c0e6113e06db7ca93b7404e78dc7ccd5ca89a4ca9").unwrap();
+
+    let (sig, _) = sk.sign_prehash_recoverable(&digest).unwrap();
+    let (r, s) = sig.split_bytes();
+
+    let mut encoded_r = [0u8; 32];
+    encoded_r.copy_from_slice(&r);
+
+    let mut encoded_s = [0u8; 32];
+    encoded_s.copy_from_slice(&s);
+
+    let mut x = [0u8; 32];
+    x.copy_from_slice(&public_key_encoded[0..32]);
+
+    let mut y = [0u8; 32];
+    y.copy_from_slice(&public_key_encoded[32..64]);
+
+    let tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: P256VERIFY_PRECOMPILE_ADDRESS,
+            calldata: [digest, encoded_r, encoded_s, x, y].concat(),
+            value: U256::zero(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    vm.vm.push_transaction(tx);
+
+    let execution_result = vm.vm.execute(VmExecutionMode::Batch);
+
+    let ExecutionResult::Success { output } = execution_result.result else {
+        panic!("batch failed")
+    };
+
+    let output = H256::from_slice(&output);
+
+    assert_eq!(
+        h256_to_u256(output),
+        U256::from(1u32),
+        "verification was not successful"
+    );
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/simple_execution.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/simple_execution.rs
@@ -1,0 +1,81 @@
+use crate::{
+    interface::{ExecutionResult, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::tester::{TxType, VmTesterBuilder},
+        HistoryDisabled,
+    },
+};
+
+#[test]
+fn estimate_fee() {
+    let mut vm_tester = VmTesterBuilder::new(HistoryDisabled)
+        .with_empty_in_memory_storage()
+        .with_deployer()
+        .with_random_rich_accounts(1)
+        .build();
+
+    vm_tester.deploy_test_contract();
+    let account = &mut vm_tester.rich_accounts[0];
+
+    let tx = account.get_test_contract_transaction(
+        vm_tester.test_contract.unwrap(),
+        false,
+        Default::default(),
+        false,
+        TxType::L2,
+    );
+
+    vm_tester.vm.push_transaction(tx);
+
+    let result = vm_tester.vm.execute(VmExecutionMode::OneTx);
+    assert!(matches!(result.result, ExecutionResult::Success { .. }));
+}
+
+#[test]
+fn simple_execute() {
+    let mut vm_tester = VmTesterBuilder::new(HistoryDisabled)
+        .with_empty_in_memory_storage()
+        .with_deployer()
+        .with_random_rich_accounts(1)
+        .build();
+
+    vm_tester.deploy_test_contract();
+
+    let account = &mut vm_tester.rich_accounts[0];
+
+    let tx1 = account.get_test_contract_transaction(
+        vm_tester.test_contract.unwrap(),
+        false,
+        Default::default(),
+        false,
+        TxType::L1 { serial_id: 1 },
+    );
+
+    let tx2 = account.get_test_contract_transaction(
+        vm_tester.test_contract.unwrap(),
+        true,
+        Default::default(),
+        false,
+        TxType::L1 { serial_id: 1 },
+    );
+
+    let tx3 = account.get_test_contract_transaction(
+        vm_tester.test_contract.unwrap(),
+        false,
+        Default::default(),
+        false,
+        TxType::L1 { serial_id: 1 },
+    );
+    let vm = &mut vm_tester.vm;
+    vm.push_transaction(tx1);
+    vm.push_transaction(tx2);
+    vm.push_transaction(tx3);
+    let tx = vm.execute(VmExecutionMode::OneTx);
+    assert!(matches!(tx.result, ExecutionResult::Success { .. }));
+    let tx = vm.execute(VmExecutionMode::OneTx);
+    assert!(matches!(tx.result, ExecutionResult::Revert { .. }));
+    let tx = vm.execute(VmExecutionMode::OneTx);
+    assert!(matches!(tx.result, ExecutionResult::Success { .. }));
+    let block_tip = vm.execute(VmExecutionMode::Batch);
+    assert!(matches!(block_tip.result, ExecutionResult::Success { .. }));
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/storage.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/storage.rs
@@ -1,0 +1,186 @@
+use ethabi::Token;
+use zksync_contracts::{load_contract, read_bytecode};
+use zksync_test_account::Account;
+use zksync_types::{fee::Fee, Address, Execute, U256};
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface, VmInterfaceHistoryEnabled},
+    vm_latest::{tests::tester::VmTesterBuilder, HistoryEnabled},
+};
+
+#[derive(Debug, Default)]
+
+struct TestTxInfo {
+    calldata: Vec<u8>,
+    fee_overrides: Option<Fee>,
+    should_fail: bool,
+}
+
+fn test_storage(txs: Vec<TestTxInfo>) -> u32 {
+    let bytecode = read_bytecode(
+        "etc/contracts-test-data/artifacts-zk/contracts/storage/storage.sol/StorageTester.json",
+    );
+
+    let test_contract_address = Address::random();
+
+    // In this test, we aim to test whether a simple account interaction (without any fee logic)
+    // will work. The account will try to deploy a simple contract from integration tests.
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_deployer()
+        .with_random_rich_accounts(txs.len() as u32)
+        .with_custom_contracts(vec![(bytecode, test_contract_address, false)])
+        .build();
+
+    let mut last_result = None;
+
+    for (id, tx) in txs.into_iter().enumerate() {
+        let TestTxInfo {
+            calldata,
+            fee_overrides,
+            should_fail,
+        } = tx;
+
+        let account = &mut vm.rich_accounts[id];
+
+        vm.vm.make_snapshot();
+
+        let tx = account.get_l2_tx_for_execute(
+            Execute {
+                contract_address: test_contract_address,
+                calldata,
+                value: 0.into(),
+                factory_deps: vec![],
+            },
+            fee_overrides,
+        );
+
+        vm.vm.push_transaction(tx);
+        let result = vm.vm.execute(VmExecutionMode::OneTx);
+        if should_fail {
+            assert!(result.result.is_failed(), "Transaction should fail");
+            vm.vm.rollback_to_the_latest_snapshot();
+        } else {
+            assert!(!result.result.is_failed(), "Transaction should not fail");
+            vm.vm.pop_snapshot_no_rollback();
+        }
+
+        last_result = Some(result);
+    }
+
+    last_result.unwrap().statistics.pubdata_published
+}
+
+fn test_storage_one_tx(second_tx_calldata: Vec<u8>) -> u32 {
+    test_storage(vec![
+        TestTxInfo::default(),
+        TestTxInfo {
+            calldata: second_tx_calldata,
+            fee_overrides: None,
+            should_fail: false,
+        },
+    ])
+}
+
+#[test]
+fn test_storage_behavior() {
+    let contract = load_contract(
+        "etc/contracts-test-data/artifacts-zk/contracts/storage/storage.sol/StorageTester.json",
+    );
+
+    // In all of the tests below we provide the first tx to ensure that the tracers will not include
+    // the statistics from the start of the bootloader and will only include those for the transaction itself.
+
+    let base_pubdata = test_storage_one_tx(vec![]);
+    let simple_test_pubdata = test_storage_one_tx(
+        contract
+            .function("simpleWrite")
+            .unwrap()
+            .encode_input(&[])
+            .unwrap(),
+    );
+    let resetting_write_pubdata = test_storage_one_tx(
+        contract
+            .function("resettingWrite")
+            .unwrap()
+            .encode_input(&[])
+            .unwrap(),
+    );
+    let resetting_write_via_revert_pubdata = test_storage_one_tx(
+        contract
+            .function("resettingWriteViaRevert")
+            .unwrap()
+            .encode_input(&[])
+            .unwrap(),
+    );
+
+    assert_eq!(simple_test_pubdata - base_pubdata, 65);
+    assert_eq!(resetting_write_pubdata - base_pubdata, 34);
+    assert_eq!(resetting_write_via_revert_pubdata - base_pubdata, 34);
+}
+
+#[test]
+fn test_transient_storage_behavior() {
+    let contract = load_contract(
+        "etc/contracts-test-data/artifacts-zk/contracts/storage/storage.sol/StorageTester.json",
+    );
+
+    let first_tstore_test = contract
+        .function("testTransientStore")
+        .unwrap()
+        .encode_input(&[])
+        .unwrap();
+    // Second transaction checks that, as expected, the transient storage is cleared after the first transaction.
+    let second_tstore_test = contract
+        .function("assertTValue")
+        .unwrap()
+        .encode_input(&[Token::Uint(U256::zero())])
+        .unwrap();
+
+    test_storage(vec![
+        TestTxInfo {
+            calldata: first_tstore_test,
+            ..TestTxInfo::default()
+        },
+        TestTxInfo {
+            calldata: second_tstore_test,
+            ..TestTxInfo::default()
+        },
+    ]);
+}
+
+#[test]
+fn test_transient_storage_behavior_panic() {
+    let contract = load_contract(
+        "etc/contracts-test-data/artifacts-zk/contracts/storage/storage.sol/StorageTester.json",
+    );
+
+    let basic_tstore_test = contract
+        .function("tStoreAndRevert")
+        .unwrap()
+        .encode_input(&[Token::Uint(U256::one()), Token::Bool(false)])
+        .unwrap();
+
+    let small_fee = Fee {
+        // Something very-very small to make the validation fail
+        gas_limit: 10_000.into(),
+        ..Account::default_fee()
+    };
+
+    test_storage(vec![
+        TestTxInfo {
+            calldata: basic_tstore_test.clone(),
+            ..TestTxInfo::default()
+        },
+        TestTxInfo {
+            fee_overrides: Some(small_fee),
+            should_fail: true,
+            ..TestTxInfo::default()
+        },
+        TestTxInfo {
+            calldata: basic_tstore_test,
+            ..TestTxInfo::default()
+        },
+    ]);
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/tester/inner_state.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/tester/inner_state.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+
+use zk_evm_1_5_0::{aux_structures::Timestamp, vm_state::VmLocalState};
+use zksync_state::WriteStorage;
+use zksync_types::{StorageKey, StorageValue, U256};
+
+use crate::{
+    era_vm::{
+        old_vm::{
+            event_sink::InMemoryEventSink,
+            history_recorder::{AppDataFrameManagerWithHistory, HistoryRecorder},
+        },
+        utils::logs::StorageLogQuery,
+        HistoryEnabled, HistoryMode, SimpleMemory, Vm,
+    },
+    HistoryMode as CommonHistoryMode,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct ModifiedKeysMap(HashMap<StorageKey, StorageValue>);
+
+// We consider hashmaps to be equal even if there is a key
+// that is not present in one but has zero value in another.
+impl PartialEq for ModifiedKeysMap {
+    fn eq(&self, other: &Self) -> bool {
+        for (key, value) in self.0.iter() {
+            if *value != other.0.get(key).cloned().unwrap_or_default() {
+                return false;
+            }
+        }
+        for (key, value) in other.0.iter() {
+            if *value != self.0.get(key).cloned().unwrap_or_default() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) struct DecommitterTestInnerState<H: HistoryMode> {
+    /// There is no way to "truly" compare the storage pointer,
+    /// so we just compare the modified keys. This is reasonable enough.
+    pub(crate) modified_storage_keys: ModifiedKeysMap,
+    pub(crate) known_bytecodes: HistoryRecorder<HashMap<U256, Vec<U256>>, H>,
+    pub(crate) decommitted_code_hashes: HistoryRecorder<HashMap<U256, Option<u32>>, HistoryEnabled>,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) struct StorageOracleInnerState<H: HistoryMode> {
+    /// There is no way to "truly" compare the storage pointer,
+    /// so we just compare the modified keys. This is reasonable enough.
+    pub(crate) modified_storage_keys: ModifiedKeysMap,
+
+    pub(crate) frames_stack: AppDataFrameManagerWithHistory<Box<StorageLogQuery>, H>,
+
+    pub(crate) paid_changes: HistoryRecorder<HashMap<StorageKey, u32>, H>,
+    pub(crate) initial_values: HistoryRecorder<HashMap<StorageKey, U256>, H>,
+    pub(crate) returned_io_refunds: HistoryRecorder<Vec<u32>, H>,
+    pub(crate) returned_pubdata_costs: HistoryRecorder<Vec<i32>, H>,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) struct PrecompileProcessorTestInnerState<H: HistoryMode> {
+    pub(crate) timestamp_history: HistoryRecorder<Vec<Timestamp>, H>,
+}
+
+/// A struct that encapsulates the state of the VM's oracles
+/// The state is to be used in tests.
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) struct VmInstanceInnerState<H: HistoryMode> {
+    event_sink: InMemoryEventSink<H>,
+    precompile_processor_state: PrecompileProcessorTestInnerState<H>,
+    memory: SimpleMemory<H>,
+    decommitter_state: DecommitterTestInnerState<H>,
+    storage_oracle_state: StorageOracleInnerState<H>,
+    local_state: VmLocalState,
+}
+
+impl<S: WriteStorage, H: CommonHistoryMode> Vm<S, H> {
+    // Dump inner state of the VM.
+    pub(crate) fn dump_inner_state(&self) -> VmInstanceInnerState<H::Vm1_5_0> {
+        let event_sink = self.state.event_sink.clone();
+        let precompile_processor_state = PrecompileProcessorTestInnerState {
+            timestamp_history: self.state.precompiles_processor.timestamp_history.clone(),
+        };
+        let memory = self.state.memory.clone();
+        let decommitter_state = DecommitterTestInnerState {
+            modified_storage_keys: ModifiedKeysMap(
+                self.state
+                    .decommittment_processor
+                    .get_storage()
+                    .borrow()
+                    .modified_storage_keys()
+                    .clone(),
+            ),
+            known_bytecodes: self.state.decommittment_processor.known_bytecodes.clone(),
+            decommitted_code_hashes: self
+                .state
+                .decommittment_processor
+                .get_decommitted_code_hashes_with_history()
+                .clone(),
+        };
+        let storage_oracle_state = StorageOracleInnerState {
+            modified_storage_keys: ModifiedKeysMap(
+                self.state
+                    .storage
+                    .storage
+                    .get_ptr()
+                    .borrow()
+                    .modified_storage_keys()
+                    .clone(),
+            ),
+            frames_stack: self.state.storage.storage_frames_stack.clone(),
+            paid_changes: self.state.storage.paid_changes.clone(),
+            initial_values: self.state.storage.initial_values.clone(),
+            returned_io_refunds: self.state.storage.returned_io_refunds.clone(),
+            returned_pubdata_costs: self.state.storage.returned_pubdata_costs.clone(),
+        };
+        let local_state = self.state.local_state.clone();
+
+        VmInstanceInnerState {
+            event_sink,
+            precompile_processor_state,
+            memory,
+            decommitter_state,
+            storage_oracle_state,
+            local_state,
+        }
+    }
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/tester/mod.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/tester/mod.rs
@@ -1,0 +1,9 @@
+pub(crate) use transaction_test_info::{ExpectedError, TransactionTestInfo, TxModifier};
+pub(crate) use vm_tester::{
+    default_l1_batch, get_empty_storage, InMemoryStorageView, VmTester, VmTesterBuilder,
+};
+pub(crate) use zksync_test_account::{Account, DeployContractsTx, TxType};
+
+mod inner_state;
+mod transaction_test_info;
+mod vm_tester;

--- a/core/lib/multivm/src/versions/era_vm/tests/tester/transaction_test_info.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/tester/transaction_test_info.rs
@@ -1,0 +1,217 @@
+use zksync_types::{ExecuteTransactionCommon, Transaction};
+
+use crate::{
+    interface::{
+        CurrentExecutionState, ExecutionResult, Halt, TxRevertReason, VmExecutionMode,
+        VmExecutionResultAndLogs, VmInterface, VmInterfaceHistoryEnabled, VmRevertReason,
+    },
+    vm_latest::{tests::tester::vm_tester::VmTester, HistoryEnabled},
+};
+
+#[derive(Debug, Clone)]
+pub(crate) enum TxModifier {
+    WrongSignatureLength,
+    WrongSignature,
+    WrongMagicValue,
+    WrongNonce,
+    NonceReused,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TxExpectedResult {
+    Rejected { error: ExpectedError },
+    Processed { rollback: bool },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TransactionTestInfo {
+    tx: Transaction,
+    result: TxExpectedResult,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExpectedError {
+    pub(crate) revert_reason: TxRevertReason,
+    pub(crate) modifier: Option<TxModifier>,
+}
+
+impl From<TxModifier> for ExpectedError {
+    fn from(value: TxModifier) -> Self {
+        let revert_reason = match value {
+            TxModifier::WrongSignatureLength => {
+                Halt::ValidationFailed(VmRevertReason::General {
+                    msg: "Signature length is incorrect".to_string(),
+                    data: vec![
+                        8, 195, 121, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 29, 83, 105, 103, 110, 97, 116, 117, 114, 101, 32,
+                        108, 101, 110, 103, 116, 104, 32, 105, 115, 32, 105, 110, 99, 111, 114, 114, 101, 99,
+                        116, 0, 0, 0,
+                    ],
+                })
+            }
+            TxModifier::WrongSignature => {
+                Halt::ValidationFailed(VmRevertReason::General {
+                    msg: "Account validation returned invalid magic value. Most often this means that the signature is incorrect".to_string(),
+                    data: vec![],
+                })
+            }
+            TxModifier::WrongMagicValue => {
+                Halt::ValidationFailed(VmRevertReason::General {
+                    msg: "v is neither 27 nor 28".to_string(),
+                    data: vec![
+                        8, 195, 121, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 22, 118, 32, 105, 115, 32, 110, 101, 105, 116, 104,
+                        101, 114, 32, 50, 55, 32, 110, 111, 114, 32, 50, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                })
+
+            }
+            TxModifier::WrongNonce => {
+                Halt::ValidationFailed(VmRevertReason::General {
+                    msg: "Incorrect nonce".to_string(),
+                    data: vec![
+                        8, 195, 121, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 73, 110, 99, 111, 114, 114, 101, 99, 116, 32, 110,
+                        111, 110, 99, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                })
+            }
+            TxModifier::NonceReused => {
+                Halt::ValidationFailed(VmRevertReason::General {
+                    msg: "Reusing the same nonce twice".to_string(),
+                    data: vec![
+                        8, 195, 121, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 28, 82, 101, 117, 115, 105, 110, 103, 32, 116, 104,
+                        101, 32, 115, 97, 109, 101, 32, 110, 111, 110, 99, 101, 32, 116, 119, 105, 99, 101, 0,
+                        0, 0, 0,
+                    ],
+                })
+            }
+        };
+
+        ExpectedError {
+            revert_reason: TxRevertReason::Halt(revert_reason),
+            modifier: Some(value),
+        }
+    }
+}
+
+impl TransactionTestInfo {
+    pub(crate) fn new_rejected(
+        mut transaction: Transaction,
+        expected_error: ExpectedError,
+    ) -> Self {
+        transaction.common_data = match transaction.common_data {
+            ExecuteTransactionCommon::L2(mut data) => {
+                if let Some(modifier) = &expected_error.modifier {
+                    match modifier {
+                        TxModifier::WrongSignatureLength => {
+                            data.signature = data.signature[..data.signature.len() - 20].to_vec()
+                        }
+                        TxModifier::WrongSignature => data.signature = vec![27u8; 65],
+                        TxModifier::WrongMagicValue => data.signature = vec![1u8; 65],
+                        TxModifier::WrongNonce => {
+                            // Do not need to modify signature for nonce error
+                        }
+                        TxModifier::NonceReused => {
+                            // Do not need to modify signature for nonce error
+                        }
+                    }
+                }
+                ExecuteTransactionCommon::L2(data)
+            }
+            _ => panic!("L1 transactions are not supported"),
+        };
+
+        Self {
+            tx: transaction,
+            result: TxExpectedResult::Rejected {
+                error: expected_error,
+            },
+        }
+    }
+
+    pub(crate) fn new_processed(transaction: Transaction, should_be_rollbacked: bool) -> Self {
+        Self {
+            tx: transaction,
+            result: TxExpectedResult::Processed {
+                rollback: should_be_rollbacked,
+            },
+        }
+    }
+
+    fn verify_result(&self, result: &VmExecutionResultAndLogs) {
+        match &self.result {
+            TxExpectedResult::Rejected { error } => match &result.result {
+                ExecutionResult::Success { .. } => {
+                    panic!("Transaction should be reverted {:?}", self.tx.nonce())
+                }
+                ExecutionResult::Revert { output } => match &error.revert_reason {
+                    TxRevertReason::TxReverted(expected) => {
+                        assert_eq!(output, expected)
+                    }
+                    _ => {
+                        panic!("Error types mismatch");
+                    }
+                },
+                ExecutionResult::Halt { reason } => match &error.revert_reason {
+                    TxRevertReason::Halt(expected) => {
+                        assert_eq!(reason, expected)
+                    }
+                    _ => {
+                        panic!("Error types mismatch");
+                    }
+                },
+            },
+            TxExpectedResult::Processed { .. } => {
+                assert!(!result.result.is_failed());
+            }
+        }
+    }
+
+    fn should_rollback(&self) -> bool {
+        match &self.result {
+            TxExpectedResult::Rejected { .. } => true,
+            TxExpectedResult::Processed { rollback } => *rollback,
+        }
+    }
+}
+
+impl VmTester<HistoryEnabled> {
+    pub(crate) fn execute_and_verify_txs(
+        &mut self,
+        txs: &[TransactionTestInfo],
+    ) -> CurrentExecutionState {
+        for tx_test_info in txs {
+            self.execute_tx_and_verify(tx_test_info.clone());
+        }
+        self.vm.execute(VmExecutionMode::Batch);
+        let mut state = self.vm.get_current_execution_state();
+        state.used_contract_hashes.sort();
+        state
+    }
+
+    pub(crate) fn execute_tx_and_verify(
+        &mut self,
+        tx_test_info: TransactionTestInfo,
+    ) -> VmExecutionResultAndLogs {
+        let inner_state_before = self.vm.dump_inner_state();
+        self.vm.make_snapshot();
+        self.vm.push_transaction(tx_test_info.tx.clone());
+        let result = self.vm.execute(VmExecutionMode::OneTx);
+        tx_test_info.verify_result(&result);
+        if tx_test_info.should_rollback() {
+            self.vm.rollback_to_the_latest_snapshot();
+            let inner_state_after = self.vm.dump_inner_state();
+            assert_eq!(
+                inner_state_before, inner_state_after,
+                "Inner state before and after rollback should be equal"
+            );
+        }
+        result
+    }
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/tester/vm_tester.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/tester/vm_tester.rs
@@ -1,0 +1,298 @@
+use std::marker::PhantomData;
+
+use zksync_contracts::BaseSystemContracts;
+use zksync_state::{InMemoryStorage, StoragePtr, StorageView, WriteStorage};
+use zksync_types::{
+    block::L2BlockHasher,
+    fee_model::BatchFeeInput,
+    get_code_key, get_is_account_key,
+    helpers::unix_timestamp_ms,
+    utils::{deployed_address_create, storage_key_for_eth_balance},
+    Address, L1BatchNumber, L2BlockNumber, L2ChainId, Nonce, ProtocolVersionId, U256,
+};
+use zksync_utils::{bytecode::hash_bytecode, u256_to_h256};
+
+use crate::{
+    interface::{
+        L1BatchEnv, L2Block, L2BlockEnv, SystemEnv, TxExecutionMode, VmExecutionMode, VmInterface,
+    },
+    vm_latest::{
+        constants::BATCH_COMPUTATIONAL_GAS_LIMIT,
+        tests::{
+            tester::{Account, TxType},
+            utils::read_test_contract,
+        },
+        utils::l2_blocks::load_last_l2_block,
+        Vm,
+    },
+    HistoryMode,
+};
+
+pub(crate) type InMemoryStorageView = StorageView<InMemoryStorage>;
+
+pub(crate) struct VmTester<H: HistoryMode> {
+    pub(crate) vm: Vm<InMemoryStorageView, H>,
+    pub(crate) storage: StoragePtr<InMemoryStorageView>,
+    pub(crate) fee_account: Address,
+    pub(crate) deployer: Option<Account>,
+    pub(crate) test_contract: Option<Address>,
+    pub(crate) rich_accounts: Vec<Account>,
+    pub(crate) custom_contracts: Vec<ContractsToDeploy>,
+    _phantom: std::marker::PhantomData<H>,
+}
+
+impl<H: HistoryMode> VmTester<H> {
+    pub(crate) fn deploy_test_contract(&mut self) {
+        let contract = read_test_contract();
+        let tx = self
+            .deployer
+            .as_mut()
+            .expect("You have to initialize builder with deployer")
+            .get_deploy_tx(&contract, None, TxType::L2)
+            .tx;
+        let nonce = tx.nonce().unwrap().0.into();
+        self.vm.push_transaction(tx);
+        self.vm.execute(VmExecutionMode::OneTx);
+        let deployed_address =
+            deployed_address_create(self.deployer.as_ref().unwrap().address, nonce);
+        self.test_contract = Some(deployed_address);
+    }
+
+    pub(crate) fn reset_with_empty_storage(&mut self) {
+        self.storage = StorageView::new(get_empty_storage()).to_rc_ptr();
+        self.reset_state(false);
+    }
+
+    /// Reset the state of the VM to the initial state.
+    /// If `use_latest_l2_block` is true, then the VM will use the latest L2 block from storage,
+    /// otherwise it will use the first L2 block of l1 batch env
+    pub(crate) fn reset_state(&mut self, use_latest_l2_block: bool) {
+        for account in self.rich_accounts.iter_mut() {
+            account.nonce = Nonce(0);
+            make_account_rich(self.storage.clone(), account);
+        }
+        if let Some(deployer) = &self.deployer {
+            make_account_rich(self.storage.clone(), deployer);
+        }
+
+        if !self.custom_contracts.is_empty() {
+            println!("Inserting custom contracts is not yet supported")
+            // `insert_contracts(&mut self.storage, &self.custom_contracts);`
+        }
+
+        let mut l1_batch = self.vm.batch_env.clone();
+        if use_latest_l2_block {
+            let last_l2_block = load_last_l2_block(self.storage.clone()).unwrap_or(L2Block {
+                number: 0,
+                timestamp: 0,
+                hash: L2BlockHasher::legacy_hash(L2BlockNumber(0)),
+            });
+            l1_batch.first_l2_block = L2BlockEnv {
+                number: last_l2_block.number + 1,
+                timestamp: std::cmp::max(last_l2_block.timestamp + 1, l1_batch.timestamp),
+                prev_block_hash: last_l2_block.hash,
+                max_virtual_blocks_to_create: 1,
+            };
+        }
+
+        let vm = Vm::new(l1_batch, self.vm.system_env.clone(), self.storage.clone());
+
+        if self.test_contract.is_some() {
+            self.deploy_test_contract();
+        }
+
+        self.vm = vm;
+    }
+}
+
+pub(crate) type ContractsToDeploy = (Vec<u8>, Address, bool);
+
+pub(crate) struct VmTesterBuilder<H: HistoryMode> {
+    storage: Option<InMemoryStorage>,
+    l1_batch_env: Option<L1BatchEnv>,
+    system_env: SystemEnv,
+    deployer: Option<Account>,
+    rich_accounts: Vec<Account>,
+    custom_contracts: Vec<ContractsToDeploy>,
+    _phantom: PhantomData<H>,
+}
+
+impl<H: HistoryMode> Clone for VmTesterBuilder<H> {
+    fn clone(&self) -> Self {
+        Self {
+            storage: None,
+            l1_batch_env: self.l1_batch_env.clone(),
+            system_env: self.system_env.clone(),
+            deployer: self.deployer.clone(),
+            rich_accounts: self.rich_accounts.clone(),
+            custom_contracts: self.custom_contracts.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl<H: HistoryMode> VmTesterBuilder<H> {
+    pub(crate) fn new(_: H) -> Self {
+        Self {
+            storage: None,
+            l1_batch_env: None,
+            system_env: SystemEnv {
+                zk_porter_available: false,
+                version: ProtocolVersionId::latest(),
+                base_system_smart_contracts: BaseSystemContracts::playground(),
+                bootloader_gas_limit: BATCH_COMPUTATIONAL_GAS_LIMIT,
+                execution_mode: TxExecutionMode::VerifyExecute,
+                default_validation_computational_gas_limit: BATCH_COMPUTATIONAL_GAS_LIMIT,
+                chain_id: L2ChainId::from(270),
+            },
+            deployer: None,
+            rich_accounts: vec![],
+            custom_contracts: vec![],
+            _phantom: PhantomData,
+        }
+    }
+
+    pub(crate) fn with_l1_batch_env(mut self, l1_batch_env: L1BatchEnv) -> Self {
+        self.l1_batch_env = Some(l1_batch_env);
+        self
+    }
+
+    pub(crate) fn with_system_env(mut self, system_env: SystemEnv) -> Self {
+        self.system_env = system_env;
+        self
+    }
+
+    pub(crate) fn with_storage(mut self, storage: InMemoryStorage) -> Self {
+        self.storage = Some(storage);
+        self
+    }
+
+    pub(crate) fn with_base_system_smart_contracts(
+        mut self,
+        base_system_smart_contracts: BaseSystemContracts,
+    ) -> Self {
+        self.system_env.base_system_smart_contracts = base_system_smart_contracts;
+        self
+    }
+
+    pub(crate) fn with_bootloader_gas_limit(mut self, gas_limit: u32) -> Self {
+        self.system_env.bootloader_gas_limit = gas_limit;
+        self
+    }
+
+    pub(crate) fn with_execution_mode(mut self, execution_mode: TxExecutionMode) -> Self {
+        self.system_env.execution_mode = execution_mode;
+        self
+    }
+
+    pub(crate) fn with_empty_in_memory_storage(mut self) -> Self {
+        self.storage = Some(get_empty_storage());
+        self
+    }
+
+    pub(crate) fn with_random_rich_accounts(mut self, number: u32) -> Self {
+        for _ in 0..number {
+            let account = Account::random();
+            self.rich_accounts.push(account);
+        }
+        self
+    }
+
+    pub(crate) fn with_rich_accounts(mut self, accounts: Vec<Account>) -> Self {
+        self.rich_accounts.extend(accounts);
+        self
+    }
+
+    pub(crate) fn with_deployer(mut self) -> Self {
+        let deployer = Account::random();
+        self.deployer = Some(deployer);
+        self
+    }
+
+    pub(crate) fn with_custom_contracts(mut self, contracts: Vec<ContractsToDeploy>) -> Self {
+        self.custom_contracts = contracts;
+        self
+    }
+
+    pub(crate) fn build(self) -> VmTester<H> {
+        let l1_batch_env = self
+            .l1_batch_env
+            .unwrap_or_else(|| default_l1_batch(L1BatchNumber(1)));
+
+        let mut raw_storage = self.storage.unwrap_or_else(get_empty_storage);
+        insert_contracts(&mut raw_storage, &self.custom_contracts);
+        let storage_ptr = StorageView::new(raw_storage).to_rc_ptr();
+        for account in self.rich_accounts.iter() {
+            make_account_rich(storage_ptr.clone(), account);
+        }
+        if let Some(deployer) = &self.deployer {
+            make_account_rich(storage_ptr.clone(), deployer);
+        }
+        let fee_account = l1_batch_env.fee_account;
+
+        let vm = Vm::new(l1_batch_env, self.system_env, storage_ptr.clone());
+
+        VmTester {
+            vm,
+            storage: storage_ptr,
+            fee_account,
+            deployer: self.deployer,
+            test_contract: None,
+            rich_accounts: self.rich_accounts.clone(),
+            custom_contracts: self.custom_contracts.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub(crate) fn default_l1_batch(number: L1BatchNumber) -> L1BatchEnv {
+    let timestamp = unix_timestamp_ms();
+    L1BatchEnv {
+        previous_batch_hash: None,
+        number,
+        timestamp,
+        fee_input: BatchFeeInput::l1_pegged(
+            50_000_000_000, // 50 gwei
+            250_000_000,    // 0.25 gwei
+        ),
+        fee_account: Address::random(),
+        enforced_base_fee: None,
+        first_l2_block: L2BlockEnv {
+            number: 1,
+            timestamp,
+            prev_block_hash: L2BlockHasher::legacy_hash(L2BlockNumber(0)),
+            max_virtual_blocks_to_create: 100,
+        },
+    }
+}
+
+pub(crate) fn make_account_rich(storage: StoragePtr<InMemoryStorageView>, account: &Account) {
+    let key = storage_key_for_eth_balance(&account.address);
+    storage
+        .as_ref()
+        .borrow_mut()
+        .set_value(key, u256_to_h256(U256::from(10u64.pow(19))));
+}
+
+pub(crate) fn get_empty_storage() -> InMemoryStorage {
+    InMemoryStorage::with_system_contracts(hash_bytecode)
+}
+
+// Inserts the contracts into the test environment, bypassing the
+// deployer system contract. Besides the reference to storage
+// it accepts a `contracts` tuple of information about the contract
+// and whether or not it is an account.
+fn insert_contracts(raw_storage: &mut InMemoryStorage, contracts: &[ContractsToDeploy]) {
+    for (contract, address, is_account) in contracts {
+        let deployer_code_key = get_code_key(address);
+        raw_storage.set_value(deployer_code_key, hash_bytecode(contract));
+
+        if *is_account {
+            let is_account_key = get_is_account_key(address);
+            raw_storage.set_value(is_account_key, u256_to_h256(1_u32.into()));
+        }
+
+        raw_storage.store_factory_dep(hash_bytecode(contract), contract.clone());
+    }
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/tracing_execution_error.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/tracing_execution_error.rs
@@ -1,0 +1,54 @@
+use zksync_types::{Execute, H160};
+
+use crate::{
+    interface::{TxExecutionMode, TxRevertReason, VmRevertReason},
+    vm_latest::{
+        tests::{
+            tester::{ExpectedError, TransactionTestInfo, VmTesterBuilder},
+            utils::{get_execute_error_calldata, read_error_contract, BASE_SYSTEM_CONTRACTS},
+        },
+        HistoryEnabled,
+    },
+};
+
+#[test]
+fn test_tracing_of_execution_errors() {
+    let contract_address = H160::random();
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_base_system_smart_contracts(BASE_SYSTEM_CONTRACTS.clone())
+        .with_custom_contracts(vec![(read_error_contract(), contract_address, false)])
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_deployer()
+        .with_random_rich_accounts(1)
+        .build();
+
+    let account = &mut vm.rich_accounts[0];
+
+    let tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address,
+            calldata: get_execute_error_calldata(),
+            value: Default::default(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    vm.execute_tx_and_verify(TransactionTestInfo::new_rejected(
+        tx,
+        ExpectedError {
+            revert_reason: TxRevertReason::TxReverted(VmRevertReason::General {
+                msg: "short".to_string(),
+                data: vec![
+                    8, 195, 121, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 115, 104, 111, 114, 116,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0,
+                ],
+            }),
+            modifier: None,
+        },
+    ));
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/transfer.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/transfer.rs
@@ -1,0 +1,220 @@
+use ethabi::Token;
+use zksync_contracts::{load_contract, read_bytecode};
+use zksync_system_constants::L2_BASE_TOKEN_ADDRESS;
+use zksync_types::{utils::storage_key_for_eth_balance, AccountTreeId, Address, Execute, U256};
+use zksync_utils::u256_to_h256;
+
+use crate::{
+    interface::{TxExecutionMode, VmExecutionMode, VmInterface},
+    vm_latest::{
+        tests::{
+            tester::{get_empty_storage, VmTesterBuilder},
+            utils::get_balance,
+        },
+        HistoryEnabled,
+    },
+};
+
+enum TestOptions {
+    Send(U256),
+    Transfer(U256),
+}
+
+fn test_send_or_transfer(test_option: TestOptions) {
+    let test_bytecode = read_bytecode(
+        "etc/contracts-test-data/artifacts-zk/contracts/transfer/transfer.sol/TransferTest.json",
+    );
+    let recipeint_bytecode = read_bytecode(
+        "etc/contracts-test-data/artifacts-zk/contracts/transfer/transfer.sol/Recipient.json",
+    );
+    let test_abi = load_contract(
+        "etc/contracts-test-data/artifacts-zk/contracts/transfer/transfer.sol/TransferTest.json",
+    );
+
+    let test_contract_address = Address::random();
+    let recipient_address = Address::random();
+
+    let (value, calldata) = match test_option {
+        TestOptions::Send(value) => (
+            value,
+            test_abi
+                .function("send")
+                .unwrap()
+                .encode_input(&[Token::Address(recipient_address), Token::Uint(value)])
+                .unwrap(),
+        ),
+        TestOptions::Transfer(value) => (
+            value,
+            test_abi
+                .function("transfer")
+                .unwrap()
+                .encode_input(&[Token::Address(recipient_address), Token::Uint(value)])
+                .unwrap(),
+        ),
+    };
+
+    let mut storage = get_empty_storage();
+    storage.set_value(
+        storage_key_for_eth_balance(&test_contract_address),
+        u256_to_h256(value),
+    );
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_storage(storage)
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_deployer()
+        .with_random_rich_accounts(1)
+        .with_custom_contracts(vec![
+            (test_bytecode, test_contract_address, false),
+            (recipeint_bytecode, recipient_address, false),
+        ])
+        .build();
+
+    let account = &mut vm.rich_accounts[0];
+    let tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: test_contract_address,
+            calldata,
+            value: U256::zero(),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    vm.vm.push_transaction(tx);
+    let tx_result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(
+        !tx_result.result.is_failed(),
+        "Transaction wasn't successful"
+    );
+
+    let batch_result = vm.vm.execute(VmExecutionMode::Batch);
+    assert!(!batch_result.result.is_failed(), "Batch wasn't successful");
+
+    let new_recipient_balance = get_balance(
+        AccountTreeId::new(L2_BASE_TOKEN_ADDRESS),
+        &recipient_address,
+        vm.vm.state.storage.storage.get_ptr(),
+    );
+
+    assert_eq!(new_recipient_balance, value);
+}
+
+#[test]
+fn test_send_and_transfer() {
+    test_send_or_transfer(TestOptions::Send(U256::zero()));
+    test_send_or_transfer(TestOptions::Send(U256::from(10).pow(18.into())));
+    test_send_or_transfer(TestOptions::Transfer(U256::zero()));
+    test_send_or_transfer(TestOptions::Transfer(U256::from(10).pow(18.into())));
+}
+
+fn test_reentrancy_protection_send_or_transfer(test_option: TestOptions) {
+    let test_bytecode = read_bytecode(
+        "etc/contracts-test-data/artifacts-zk/contracts/transfer/transfer.sol/TransferTest.json",
+    );
+    let reentrant_recipeint_bytecode = read_bytecode(
+        "etc/contracts-test-data/artifacts-zk/contracts/transfer/transfer.sol/ReentrantRecipient.json",
+    );
+    let test_abi = load_contract(
+        "etc/contracts-test-data/artifacts-zk/contracts/transfer/transfer.sol/TransferTest.json",
+    );
+    let reentrant_recipient_abi = load_contract(
+        "etc/contracts-test-data/artifacts-zk/contracts/transfer/transfer.sol/ReentrantRecipient.json",
+    );
+
+    let test_contract_address = Address::random();
+    let reentrant_recipeint_address = Address::random();
+
+    let (value, calldata) = match test_option {
+        TestOptions::Send(value) => (
+            value,
+            test_abi
+                .function("send")
+                .unwrap()
+                .encode_input(&[
+                    Token::Address(reentrant_recipeint_address),
+                    Token::Uint(value),
+                ])
+                .unwrap(),
+        ),
+        TestOptions::Transfer(value) => (
+            value,
+            test_abi
+                .function("transfer")
+                .unwrap()
+                .encode_input(&[
+                    Token::Address(reentrant_recipeint_address),
+                    Token::Uint(value),
+                ])
+                .unwrap(),
+        ),
+    };
+
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_deployer()
+        .with_random_rich_accounts(1)
+        .with_custom_contracts(vec![
+            (test_bytecode, test_contract_address, false),
+            (
+                reentrant_recipeint_bytecode,
+                reentrant_recipeint_address,
+                false,
+            ),
+        ])
+        .build();
+
+    // First transaction, the job of which is to warm up the slots for balance of the recipient as well as its storage variable.
+    let account = &mut vm.rich_accounts[0];
+    let tx1 = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: reentrant_recipeint_address,
+            calldata: reentrant_recipient_abi
+                .function("setX")
+                .unwrap()
+                .encode_input(&[])
+                .unwrap(),
+            value: U256::from(1),
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    vm.vm.push_transaction(tx1);
+    let tx1_result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(
+        !tx1_result.result.is_failed(),
+        "Transaction 1 wasn't successful"
+    );
+
+    let tx2 = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: test_contract_address,
+            calldata,
+            value,
+            factory_deps: vec![],
+        },
+        None,
+    );
+
+    vm.vm.push_transaction(tx2);
+    let tx2_result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(
+        tx2_result.result.is_failed(),
+        "Transaction 2 should have failed, but it succeeded"
+    );
+
+    let batch_result = vm.vm.execute(VmExecutionMode::Batch);
+    assert!(!batch_result.result.is_failed(), "Batch wasn't successful");
+}
+
+#[test]
+fn test_reentrancy_protection_send_and_transfer() {
+    test_reentrancy_protection_send_or_transfer(TestOptions::Send(U256::zero()));
+    test_reentrancy_protection_send_or_transfer(TestOptions::Send(U256::from(10).pow(18.into())));
+    test_reentrancy_protection_send_or_transfer(TestOptions::Transfer(U256::zero()));
+    test_reentrancy_protection_send_or_transfer(TestOptions::Transfer(
+        U256::from(10).pow(18.into()),
+    ));
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/upgrade.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/upgrade.rs
@@ -1,0 +1,355 @@
+use zk_evm_1_5_0::aux_structures::Timestamp;
+use zksync_contracts::{deployer_contract, load_sys_contract, read_bytecode};
+use zksync_state::WriteStorage;
+use zksync_test_account::TxType;
+use zksync_types::{
+    ethabi::{Contract, Token},
+    get_code_key, get_known_code_key,
+    protocol_upgrade::ProtocolUpgradeTxCommonData,
+    Address, Execute, ExecuteTransactionCommon, Transaction, COMPLEX_UPGRADER_ADDRESS,
+    CONTRACT_DEPLOYER_ADDRESS, CONTRACT_FORCE_DEPLOYER_ADDRESS, H160, H256,
+    REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256,
+};
+use zksync_utils::{bytecode::hash_bytecode, bytes_to_be_words, h256_to_u256, u256_to_h256};
+
+use super::utils::{get_complex_upgrade_abi, read_test_contract};
+use crate::{
+    interface::{
+        ExecutionResult, Halt, TxExecutionMode, VmExecutionMode, VmInterface,
+        VmInterfaceHistoryEnabled,
+    },
+    vm_latest::{
+        tests::{
+            tester::VmTesterBuilder,
+            utils::{read_complex_upgrade, verify_required_storage},
+        },
+        HistoryEnabled,
+    },
+};
+
+/// In this test we ensure that the requirements for protocol upgrade transactions are enforced by the bootloader:
+/// - This transaction must be the only one in block
+/// - If present, this transaction must be the first one in block
+#[test]
+fn test_protocol_upgrade_is_first() {
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let bytecode_hash = hash_bytecode(&read_test_contract());
+    vm.vm
+        .storage
+        .borrow_mut()
+        .set_value(get_known_code_key(&bytecode_hash), u256_to_h256(1.into()));
+
+    // Here we just use some random transaction of protocol upgrade type:
+    let protocol_upgrade_transaction = get_forced_deploy_tx(&[ForceDeployment {
+        // The bytecode hash to put on an address
+        bytecode_hash,
+        // The address on which to deploy the bytecode hash to
+        address: H160::random(),
+        // Whether to run the constructor on the force deployment
+        call_constructor: false,
+        // The value with which to initialize a contract
+        value: U256::zero(),
+        // The constructor calldata
+        input: vec![],
+    }]);
+
+    // Another random upgrade transaction
+    let another_protocol_upgrade_transaction = get_forced_deploy_tx(&[ForceDeployment {
+        // The bytecode hash to put on an address
+        bytecode_hash,
+        // The address on which to deploy the bytecode hash to
+        address: H160::random(),
+        // Whether to run the constructor on the force deployment
+        call_constructor: false,
+        // The value with which to initialize a contract
+        value: U256::zero(),
+        // The constructor calldata
+        input: vec![],
+    }]);
+
+    let normal_l1_transaction = vm.rich_accounts[0]
+        .get_deploy_tx(&read_test_contract(), None, TxType::L1 { serial_id: 0 })
+        .tx;
+
+    let expected_error =
+        Halt::UnexpectedVMBehavior("Assertion error: Protocol upgrade tx not first".to_string());
+
+    vm.vm.make_snapshot();
+    // Test 1: there must be only one system transaction in block
+    vm.vm.push_transaction(protocol_upgrade_transaction.clone());
+    vm.vm.push_transaction(normal_l1_transaction.clone());
+    vm.vm.push_transaction(another_protocol_upgrade_transaction);
+
+    vm.vm.execute(VmExecutionMode::OneTx);
+    vm.vm.execute(VmExecutionMode::OneTx);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert_eq!(
+        result.result,
+        ExecutionResult::Halt {
+            reason: expected_error.clone()
+        }
+    );
+
+    // Test 2: the protocol upgrade tx must be the first one in block
+    vm.vm.rollback_to_the_latest_snapshot();
+    vm.vm.make_snapshot();
+    vm.vm.push_transaction(normal_l1_transaction.clone());
+    vm.vm.push_transaction(protocol_upgrade_transaction.clone());
+
+    vm.vm.execute(VmExecutionMode::OneTx);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert_eq!(
+        result.result,
+        ExecutionResult::Halt {
+            reason: expected_error
+        }
+    );
+
+    vm.vm.rollback_to_the_latest_snapshot();
+    vm.vm.make_snapshot();
+    vm.vm.push_transaction(protocol_upgrade_transaction);
+    vm.vm.push_transaction(normal_l1_transaction);
+
+    vm.vm.execute(VmExecutionMode::OneTx);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(!result.result.is_failed());
+}
+
+/// In this test we try to test how force deployments could be done via protocol upgrade transactions.
+#[test]
+fn test_force_deploy_upgrade() {
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let storage_view = vm.storage.clone();
+    let bytecode_hash = hash_bytecode(&read_test_contract());
+
+    let known_code_key = get_known_code_key(&bytecode_hash);
+    // It is generally expected that all the keys will be set as known prior to the protocol upgrade.
+    storage_view
+        .borrow_mut()
+        .set_value(known_code_key, u256_to_h256(1.into()));
+    drop(storage_view);
+
+    let address_to_deploy = H160::random();
+    // Here we just use some random transaction of protocol upgrade type:
+    let transaction = get_forced_deploy_tx(&[ForceDeployment {
+        // The bytecode hash to put on an address
+        bytecode_hash,
+        // The address on which to deploy the bytecode hash to
+        address: address_to_deploy,
+        // Whether to run the constructor on the force deployment
+        call_constructor: false,
+        // The value with which to initialize a contract
+        value: U256::zero(),
+        // The constructor calldata
+        input: vec![],
+    }]);
+
+    vm.vm.push_transaction(transaction);
+
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(
+        !result.result.is_failed(),
+        "The force upgrade was not successful"
+    );
+
+    let expected_slots = vec![(bytecode_hash, get_code_key(&address_to_deploy))];
+
+    // Verify that the bytecode has been set correctly
+    verify_required_storage(&vm.vm.state, expected_slots);
+}
+
+/// Here we show how the work with the complex upgrader could be done
+#[test]
+fn test_complex_upgrader() {
+    let mut vm = VmTesterBuilder::new(HistoryEnabled)
+        .with_empty_in_memory_storage()
+        .with_execution_mode(TxExecutionMode::VerifyExecute)
+        .with_random_rich_accounts(1)
+        .build();
+
+    let storage_view = vm.storage.clone();
+
+    let bytecode_hash = hash_bytecode(&read_complex_upgrade());
+    let msg_sender_test_hash = hash_bytecode(&read_msg_sender_test());
+
+    // Let's assume that the bytecode for the implementation of the complex upgrade
+    // is already deployed in some address in user space
+    let upgrade_impl = H160::random();
+    let account_code_key = get_code_key(&upgrade_impl);
+
+    storage_view
+        .borrow_mut()
+        .set_value(get_known_code_key(&bytecode_hash), u256_to_h256(1.into()));
+    storage_view.borrow_mut().set_value(
+        get_known_code_key(&msg_sender_test_hash),
+        u256_to_h256(1.into()),
+    );
+    storage_view
+        .borrow_mut()
+        .set_value(account_code_key, bytecode_hash);
+    drop(storage_view);
+
+    vm.vm.state.decommittment_processor.populate(
+        vec![
+            (
+                h256_to_u256(bytecode_hash),
+                bytes_to_be_words(read_complex_upgrade()),
+            ),
+            (
+                h256_to_u256(msg_sender_test_hash),
+                bytes_to_be_words(read_msg_sender_test()),
+            ),
+        ],
+        Timestamp(0),
+    );
+
+    let address_to_deploy1 = H160::random();
+    let address_to_deploy2 = H160::random();
+
+    let transaction = get_complex_upgrade_tx(
+        upgrade_impl,
+        address_to_deploy1,
+        address_to_deploy2,
+        bytecode_hash,
+    );
+
+    vm.vm.push_transaction(transaction);
+    let result = vm.vm.execute(VmExecutionMode::OneTx);
+    assert!(
+        !result.result.is_failed(),
+        "The force upgrade was not successful"
+    );
+
+    let expected_slots = vec![
+        (bytecode_hash, get_code_key(&address_to_deploy1)),
+        (bytecode_hash, get_code_key(&address_to_deploy2)),
+    ];
+
+    // Verify that the bytecode has been set correctly
+    verify_required_storage(&vm.vm.state, expected_slots);
+}
+
+#[derive(Debug, Clone)]
+struct ForceDeployment {
+    // The bytecode hash to put on an address
+    bytecode_hash: H256,
+    // The address on which to deploy the bytecode hash to
+    address: Address,
+    // Whether to run the constructor on the force deployment
+    call_constructor: bool,
+    // The value with which to initialize a contract
+    value: U256,
+    // The constructor calldata
+    input: Vec<u8>,
+}
+
+fn get_forced_deploy_tx(deployment: &[ForceDeployment]) -> Transaction {
+    let deployer = deployer_contract();
+    let contract_function = deployer.function("forceDeployOnAddresses").unwrap();
+
+    let encoded_deployments: Vec<_> = deployment
+        .iter()
+        .map(|deployment| {
+            Token::Tuple(vec![
+                Token::FixedBytes(deployment.bytecode_hash.as_bytes().to_vec()),
+                Token::Address(deployment.address),
+                Token::Bool(deployment.call_constructor),
+                Token::Uint(deployment.value),
+                Token::Bytes(deployment.input.clone()),
+            ])
+        })
+        .collect();
+
+    let params = [Token::Array(encoded_deployments)];
+
+    let calldata = contract_function
+        .encode_input(&params)
+        .expect("failed to encode parameters");
+
+    let execute = Execute {
+        contract_address: CONTRACT_DEPLOYER_ADDRESS,
+        calldata,
+        factory_deps: vec![],
+        value: U256::zero(),
+    };
+
+    Transaction {
+        common_data: ExecuteTransactionCommon::ProtocolUpgrade(ProtocolUpgradeTxCommonData {
+            sender: CONTRACT_FORCE_DEPLOYER_ADDRESS,
+            gas_limit: U256::from(200_000_000u32),
+            gas_per_pubdata_limit: REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE.into(),
+            ..Default::default()
+        }),
+        execute,
+        received_timestamp_ms: 0,
+        raw_bytes: None,
+    }
+}
+
+// Returns the transaction that performs a complex protocol upgrade.
+// The first param is the address of the implementation of the complex upgrade
+// in user-space, while the next 3 params are params of the implementation itself
+// For the explanation for the parameters, please refer to:
+// etc/contracts-test-data/complex-upgrade/complex-upgrade.sol
+fn get_complex_upgrade_tx(
+    implementation_address: Address,
+    address1: Address,
+    address2: Address,
+    bytecode_hash: H256,
+) -> Transaction {
+    let impl_contract = get_complex_upgrade_abi();
+    let impl_function = impl_contract.function("someComplexUpgrade").unwrap();
+    let impl_calldata = impl_function
+        .encode_input(&[
+            Token::Address(address1),
+            Token::Address(address2),
+            Token::FixedBytes(bytecode_hash.as_bytes().to_vec()),
+        ])
+        .unwrap();
+
+    let complex_upgrader = get_complex_upgrader_abi();
+    let upgrade_function = complex_upgrader.function("upgrade").unwrap();
+    let complex_upgrader_calldata = upgrade_function
+        .encode_input(&[
+            Token::Address(implementation_address),
+            Token::Bytes(impl_calldata),
+        ])
+        .unwrap();
+
+    let execute = Execute {
+        contract_address: COMPLEX_UPGRADER_ADDRESS,
+        calldata: complex_upgrader_calldata,
+        factory_deps: vec![],
+        value: U256::zero(),
+    };
+
+    Transaction {
+        common_data: ExecuteTransactionCommon::ProtocolUpgrade(ProtocolUpgradeTxCommonData {
+            sender: CONTRACT_FORCE_DEPLOYER_ADDRESS,
+            gas_limit: U256::from(200_000_000u32),
+            gas_per_pubdata_limit: REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE.into(),
+            ..Default::default()
+        }),
+        execute,
+        received_timestamp_ms: 0,
+        raw_bytes: None,
+    }
+}
+
+fn read_msg_sender_test() -> Vec<u8> {
+    read_bytecode("etc/contracts-test-data/artifacts-zk/contracts/complex-upgrade/msg-sender.sol/MsgSenderTest.json")
+}
+
+fn get_complex_upgrader_abi() -> Contract {
+    load_sys_contract("ComplexUpgrader")
+}

--- a/core/lib/multivm/src/versions/era_vm/tests/utils.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/utils.rs
@@ -1,0 +1,133 @@
+use ethabi::Contract;
+use once_cell::sync::Lazy;
+use zksync_contracts::{
+    load_contract, read_bytecode, read_zbin_bytecode, BaseSystemContracts, SystemContractCode,
+};
+use zksync_state::{StoragePtr, WriteStorage};
+use zksync_types::{
+    utils::storage_key_for_standard_token_balance, AccountTreeId, Address, StorageKey, H256, U256,
+};
+use zksync_utils::{bytecode::hash_bytecode, bytes_to_be_words, h256_to_u256, u256_to_h256};
+
+use crate::vm_latest::{
+    tests::tester::InMemoryStorageView, types::internals::ZkSyncVmState, HistoryMode,
+};
+
+pub(crate) static BASE_SYSTEM_CONTRACTS: Lazy<BaseSystemContracts> =
+    Lazy::new(BaseSystemContracts::load_from_disk);
+
+// Probably make it a part of vm tester
+pub(crate) fn verify_required_storage<H: HistoryMode>(
+    state: &ZkSyncVmState<InMemoryStorageView, H>,
+    required_values: Vec<(H256, StorageKey)>,
+) {
+    for (required_value, key) in required_values {
+        let current_value = state.storage.storage.read_from_storage(&key);
+
+        assert_eq!(
+            u256_to_h256(current_value),
+            required_value,
+            "Invalid value at key {key:?}"
+        );
+    }
+}
+
+pub(crate) fn verify_required_memory<H: HistoryMode>(
+    state: &ZkSyncVmState<InMemoryStorageView, H>,
+    required_values: Vec<(U256, u32, u32)>,
+) {
+    for (required_value, memory_page, cell) in required_values {
+        let current_value = state
+            .memory
+            .read_slot(memory_page as usize, cell as usize)
+            .value;
+        assert_eq!(current_value, required_value);
+    }
+}
+
+pub(crate) fn get_balance<S: WriteStorage>(
+    token_id: AccountTreeId,
+    account: &Address,
+    main_storage: StoragePtr<S>,
+) -> U256 {
+    let key = storage_key_for_standard_token_balance(token_id, account);
+    h256_to_u256(main_storage.borrow_mut().read_value(&key))
+}
+
+pub(crate) fn read_test_contract() -> Vec<u8> {
+    read_bytecode("etc/contracts-test-data/artifacts-zk/contracts/counter/counter.sol/Counter.json")
+}
+
+pub(crate) fn get_bootloader(test: &str) -> SystemContractCode {
+    let bootloader_code = read_zbin_bytecode(format!(
+        "contracts/system-contracts/bootloader/tests/artifacts/{}.yul.zbin",
+        test
+    ));
+
+    let bootloader_hash = hash_bytecode(&bootloader_code);
+    SystemContractCode {
+        code: bytes_to_be_words(bootloader_code),
+        hash: bootloader_hash,
+    }
+}
+
+pub(crate) fn read_nonce_holder_tester() -> Vec<u8> {
+    read_bytecode("etc/contracts-test-data/artifacts-zk/contracts/custom-account/nonce-holder-test.sol/NonceHolderTest.json")
+}
+
+pub(crate) fn read_error_contract() -> Vec<u8> {
+    read_bytecode(
+        "etc/contracts-test-data/artifacts-zk/contracts/error/error.sol/SimpleRequire.json",
+    )
+}
+
+pub(crate) fn read_simple_transfer_contract() -> Vec<u8> {
+    read_bytecode(
+        "etc/contracts-test-data/artifacts-zk/contracts/simple-transfer/simple-transfer.sol/SimpleTransfer.json",
+    )
+}
+
+pub(crate) fn get_execute_error_calldata() -> Vec<u8> {
+    let test_contract = load_contract(
+        "etc/contracts-test-data/artifacts-zk/contracts/error/error.sol/SimpleRequire.json",
+    );
+
+    let function = test_contract.function("require_short").unwrap();
+
+    function
+        .encode_input(&[])
+        .expect("failed to encode parameters")
+}
+
+pub(crate) fn read_many_owners_custom_account_contract() -> (Vec<u8>, Contract) {
+    let path = "etc/contracts-test-data/artifacts-zk/contracts/custom-account/many-owners-custom-account.sol/ManyOwnersCustomAccount.json";
+    (read_bytecode(path), load_contract(path))
+}
+
+pub(crate) fn read_max_depth_contract() -> Vec<u8> {
+    read_zbin_bytecode(
+        "core/tests/ts-integration/contracts/zkasm/artifacts/deep_stak.zkasm/deep_stak.zkasm.zbin",
+    )
+}
+
+pub(crate) fn read_precompiles_contract() -> Vec<u8> {
+    read_bytecode(
+        "etc/contracts-test-data/artifacts-zk/contracts/precompiles/precompiles.sol/Precompiles.json",
+    )
+}
+
+pub(crate) fn load_precompiles_contract() -> Contract {
+    load_contract(
+        "etc/contracts-test-data/artifacts-zk/contracts/precompiles/precompiles.sol/Precompiles.json",
+    )
+}
+
+pub(crate) fn read_complex_upgrade() -> Vec<u8> {
+    read_bytecode("etc/contracts-test-data/artifacts-zk/contracts/complex-upgrade/complex-upgrade.sol/ComplexUpgrade.json")
+}
+
+pub(crate) fn get_complex_upgrade_abi() -> Contract {
+    load_contract(
+        "etc/contracts-test-data/artifacts-zk/contracts/complex-upgrade/complex-upgrade.sol/ComplexUpgrade.json"
+    )
+}


### PR DESCRIPTION
## What ❔

This pr enables the tests under this [folder](https://github.com/lambdaclass/zksync-era/tree/era_vm_integration/core/lib/multivm/src/versions/vm_latest/tests) to the lambda_vm

## Why ❔

This is to ensure all tests pass in the lambda_vm.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
