### PR TITLE
Fix get_used_contracts tests

### DIFF
--- a/core/lib/multivm/src/versions/era_vm/tests/get_used_contracts.rs
+++ b/core/lib/multivm/src/versions/era_vm/tests/get_used_contracts.rs
@@ -41,7 +41,7 @@ fn test_get_used_contracts() {
         .vm
         .inner
         .contract_storage
-        .borrow()
+        .borrow_mut()
         .decommit(h256_to_u256(tx.bytecode_hash))
         .is_ok());
 
@@ -53,24 +53,8 @@ fn test_get_used_contracts() {
             .inner
             .contract_storage
             .borrow()
-            .hash_map()
-            .unwrap()
-            .keys()
-            .copied()
-            .collect::<HashSet<_>>()
-            .len(),
-        known_bytecodes_without_aa_code(&vm.vm).len()
-    );
-    assert_eq!(
-        vm.vm
-            .inner
-            .contract_storage
-            .borrow()
-            .hash_map()
-            .unwrap()
-            .keys()
-            .copied()
-            .collect::<HashSet<_>>(),
+            .decommited_hashes()
+            .unwrap(),
         known_bytecodes_without_aa_code(&vm.vm)
     );
 
@@ -110,20 +94,16 @@ fn test_get_used_contracts() {
             .inner
             .contract_storage
             .borrow()
-            .hash_map()
+            .decommited_hashes()
             .unwrap()
-            .keys()
             .contains(&hash_to_u256));
     }
 }
 
 fn known_bytecodes_without_aa_code<S: ReadStorage>(vm: &Vm<S>) -> HashSet<U256> {
     let mut known_bytecodes_without_aa_code = vm
-        .inner
-        .contract_storage
+        .program_cache
         .borrow()
-        .hash_map()
-        .unwrap()
         .keys()
         .copied()
         .collect::<HashSet<_>>();


### PR DESCRIPTION

## What ❔
This fixes get_used_contracts tests, which required to keep track of those contracts that have been decommit(aka used).

Merge once [this pr](https://github.com/lambdaclass/era_vm/pull/193) gets merged on `era_vm`

## Why ❔

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
