### PR TITLE
Adapt era_vm to new world struct

### DIFF
--- a/core/lib/multivm/src/lib.rs
+++ b/core/lib/multivm/src/lib.rs
@@ -12,8 +12,8 @@ pub use crate::{
         tracers::{MultiVMTracer, MultiVmTracerPointer},
     },
     versions::{
-        vm_1_3_2, vm_1_4_1, vm_1_4_2, vm_boojum_integration, vm_fast, vm_latest, vm_m5, vm_m6,
-        vm_refunds_enhancement, vm_virtual_blocks, era_vm,
+        era_vm, vm_1_3_2, vm_1_4_1, vm_1_4_2, vm_boojum_integration, vm_fast, vm_latest, vm_m5,
+        vm_m6, vm_refunds_enhancement, vm_virtual_blocks,
     },
     vm_instance::VmInstance,
 };

--- a/core/lib/multivm/src/versions/era_vm/event.rs
+++ b/core/lib/multivm/src/versions/era_vm/event.rs
@@ -1,4 +1,4 @@
-use era_vm::world::Event;
+use era_vm::state::Event;
 use zksync_types::{L1BatchNumber, VmEvent, H256};
 use zksync_utils::h256_to_account_address;
 

--- a/core/lib/multivm/src/versions/era_vm/event.rs
+++ b/core/lib/multivm/src/versions/era_vm/event.rs
@@ -1,4 +1,4 @@
-use era_vm::state::Event;
+use era_vm::world::Event;
 use zksync_types::{L1BatchNumber, VmEvent, H256};
 use zksync_utils::h256_to_account_address;
 

--- a/core/lib/multivm/src/versions/era_vm/snapshot.rs
+++ b/core/lib/multivm/src/versions/era_vm/snapshot.rs
@@ -25,7 +25,7 @@ pub(crate) struct L2BlockSnapshot {
 }
 
 pub struct VmSnapshot {
-    state: era_vm::VMState,
+    execution: era_vm::execution::Execution,
 
     // TODO: Implement snapshots in era vm
     // world_snapshot: vm2::ExternalSnapshot,

--- a/core/lib/multivm/src/versions/era_vm/vm.rs
+++ b/core/lib/multivm/src/versions/era_vm/vm.rs
@@ -1,12 +1,12 @@
-use std::{cell::RefCell, collections::HashMap, fmt::Write, io::Read, rc::Rc, str::FromStr};
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use era_vm::{
-    store::{L2ToL1Log, StorageError, StorageKey as EraStorageKey},
+    store::{StorageError, StorageKey as EraStorageKey},
     vm::ExecutionOutput,
+    world::L2ToL1Log,
     EraVM, VMState,
 };
-use once_cell::sync::Lazy;
-use zksync_state::{InMemoryStorage, ReadStorage, StoragePtr, StorageView, WriteStorage};
+use zksync_state::{ReadStorage, StoragePtr};
 use zksync_types::{
     l1::is_l1_tx_type, AccountTreeId, StorageKey, Transaction, BOOTLOADER_ADDRESS, H160,
     KNOWN_CODES_STORAGE_ADDRESS, U256,
@@ -25,13 +25,15 @@ use super::{
 };
 use crate::{
     era_vm::{bytecode::compress_bytecodes, transaction_data::TransactionData},
-    interface::{Halt, TxRevertReason, VmFactory, VmInterface, VmInterfaceHistoryEnabled, VmRevertReason},
+    interface::{
+        Halt, TxRevertReason, VmFactory, VmInterface, VmInterfaceHistoryEnabled, VmRevertReason,
+    },
     vm_latest::{
         constants::{
             get_vm_hook_position, get_vm_hook_start_position_latest, VM_HOOK_PARAMS_COUNT,
         },
-        BootloaderMemory, CurrentExecutionState, ExecutionResult, HistoryEnabled, L1BatchEnv,
-        L2BlockEnv, SystemEnv, VmExecutionLogs, VmExecutionMode, VmExecutionResultAndLogs,
+        BootloaderMemory, CurrentExecutionState, ExecutionResult, L1BatchEnv, L2BlockEnv,
+        SystemEnv, VmExecutionLogs, VmExecutionMode, VmExecutionResultAndLogs,
     },
 };
 
@@ -87,12 +89,7 @@ impl<S: ReadStorage + 'static> VmFactory<S> for Vm<S> {
         );
         let pre_contract_storage = Rc::new(RefCell::new(HashMap::new()));
         pre_contract_storage.borrow_mut().insert(
-            h256_to_u256(
-                system_env
-                    .base_system_smart_contracts
-                    .default_aa
-                    .hash,
-            ),
+            h256_to_u256(system_env.base_system_smart_contracts.default_aa.hash),
             system_env
                 .base_system_smart_contracts
                 .default_aa
@@ -125,8 +122,7 @@ impl<S: ReadStorage + 'static> VmFactory<S> for Vm<S> {
         let mut mv = Self {
             inner: vm,
             suspended_at: 0,
-            gas_for_account_validation: system_env
-                .default_validation_computational_gas_limit,
+            gas_for_account_validation: system_env.default_validation_computational_gas_limit,
             last_tx_result: None,
             bootloader_state: BootloaderState::new(
                 system_env.execution_mode.clone(),
@@ -143,7 +139,6 @@ impl<S: ReadStorage + 'static> VmFactory<S> for Vm<S> {
         mv.write_to_bootloader_heap(bootloader_memory);
         mv
     }
-
 }
 
 impl<S: ReadStorage + 'static> Vm<S> {
@@ -254,7 +249,9 @@ impl<S: ReadStorage + 'static> Vm<S> {
                 }
                 Hook::TxHasEnded => {
                     // println!("TX HAS ENDED");
-                    if let (VmExecutionMode::OneTx, Some(result)) = (execution_mode, self.last_tx_result.take()) {
+                    if let (VmExecutionMode::OneTx, Some(result)) =
+                        (execution_mode, self.last_tx_result.take())
+                    {
                         return result;
                     }
                 }
@@ -355,7 +352,7 @@ impl<S: ReadStorage + 'static> VmInterface for Vm<S> {
         } else {
             compress_bytecodes(&tx.factory_deps, |hash| {
                 self.inner
-                    .state_storage
+                    .world
                     .storage_read(EraStorageKey::new(
                         KNOWN_CODES_STORAGE_ADDRESS,
                         h256_to_u256(hash),
@@ -400,7 +397,7 @@ impl<S: ReadStorage + 'static> VmInterface for Vm<S> {
             result,
             logs: VmExecutionLogs {
                 storage_logs: Default::default(),
-                events: merge_events(&self.inner.state.events, self.batch_env.number),
+                events: merge_events(self.inner.world.events(), self.batch_env.number),
                 user_l2_to_l1_logs: Default::default(),
                 system_l2_to_l1_logs: Default::default(),
                 total_log_queries_count: 0, // This field is unused

--- a/core/lib/multivm/src/versions/mod.rs
+++ b/core/lib/multivm/src/versions/mod.rs
@@ -1,5 +1,5 @@
-pub mod shadow;
 pub mod era_vm;
+pub mod shadow;
 pub mod vm_1_3_2;
 pub mod vm_1_4_1;
 pub mod vm_1_4_2;


### PR DESCRIPTION
## What ❔

Adapts the `era_vm` to the new world struct. Merge once [this pr](https://github.com/lambdaclass/era_vm/pull/197) gets merged.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
