### PR TITLE
Adapt era_vm to new Storage

### DIFF
--- a/core/lib/multivm/src/versions/era_vm/bytecode.rs
+++ b/core/lib/multivm/src/versions/era_vm/bytecode.rs
@@ -4,7 +4,7 @@ use zksync_utils::bytecode::{compress_bytecode, hash_bytecode, CompressedBytecod
 
 pub(crate) fn compress_bytecodes(
     bytecodes: &[Vec<u8>],
-    is_bytecode_known: impl Fn(H256) -> bool,
+    mut is_bytecode_known: impl FnMut(H256) -> bool,
 ) -> Vec<CompressedBytecodeInfo> {
     bytecodes
         .iter()


### PR DESCRIPTION
## What ❔

Adapts vm to new Storage changes necessary for pubdata and refunds implementation. See [here](https://github.com/lambdaclass/era_vm/pull/200/files).

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
