### PR TITLE
Fix blob_tracer return when running program

### DIFF
--- a/core/lib/multivm/src/versions/era_vm/vm.rs
+++ b/core/lib/multivm/src/versions/era_vm/vm.rs
@@ -167,7 +167,7 @@ impl<S: ReadStorage + 'static> Vm<S> {
         let mut last_tx_result = None;
 
         loop {
-            let (result, _blob_tracer) = self.inner.run_program_with_custom_bytecode();
+            let result = self.inner.run_program_with_custom_bytecode();
 
             let result = match result {
                 ExecutionOutput::Ok(output) => {


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Fixes the return value when running opcodes. The `blob_tracer` isn't part part of the result anymore.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
