### PR TITLE
feat(eigen-client-extra-features): Remove unused custom quorum numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8294,6 +8294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d25269dd3a12467afe2e510f69fb0b46b698e5afb296b59f2145259deaf8e8"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8336,6 +8345,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
 
 [[package]]
 name = "seahash"
@@ -8728,6 +8743,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures 0.3.31",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -12151,6 +12191,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.8",
  "sha3 0.10.8",
  "subxt-metadata",

--- a/core/lib/config/src/configs/da_client/eigen.rs
+++ b/core/lib/config/src/configs/da_client/eigen.rs
@@ -23,7 +23,6 @@ pub struct MemStoreConfig {
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Default)]
 pub struct DisperserConfig {
-    pub custom_quorum_numbers: Option<Vec<u32>>,
     pub disperser_rpc: String,
     pub eth_confirmation_depth: i32,
     pub eigenda_eth_rpc: String,

--- a/core/lib/env_config/src/da_client.rs
+++ b/core/lib/env_config/src/da_client.rs
@@ -307,7 +307,6 @@ mod tests {
         assert_eq!(
             actual,
             DAClientConfig::Eigen(EigenConfig::Disperser(DisperserConfig {
-                custom_quorum_numbers: None,
                 disperser_rpc: "http://localhost:8080".to_string(),
                 eth_confirmation_depth: 0,
                 eigenda_eth_rpc: "http://localhost:8545".to_string(),

--- a/core/lib/protobuf_config/src/da_client.rs
+++ b/core/lib/protobuf_config/src/da_client.rs
@@ -73,7 +73,6 @@ impl ProtoRepr for proto::DataAvailabilityClient {
                     }
                     proto::eigen_config::Config::Disperser(conf) => {
                         EigenConfig::Disperser(DisperserConfig {
-                            custom_quorum_numbers: Some(conf.custom_quorum_numbers.clone()),
                             disperser_rpc: required(&conf.disperser_rpc)
                                 .context("disperser_rpc")?
                                 .clone(),
@@ -167,10 +166,6 @@ impl ProtoRepr for proto::DataAvailabilityClient {
                     proto::data_availability_client::Config::Eigen(proto::EigenConfig {
                         config: Some(proto::eigen_config::Config::Disperser(
                             proto::DisperserConfig {
-                                custom_quorum_numbers: config
-                                    .custom_quorum_numbers
-                                    .clone()
-                                    .unwrap_or_default(),
                                 disperser_rpc: Some(config.disperser_rpc.clone()),
                                 eth_confirmation_depth: Some(config.eth_confirmation_depth),
                                 eigenda_eth_rpc: Some(config.eigenda_eth_rpc.clone()),

--- a/core/lib/protobuf_config/src/proto/config/da_client.proto
+++ b/core/lib/protobuf_config/src/proto/config/da_client.proto
@@ -44,7 +44,6 @@ message MemStoreConfig {
 }
 
 message DisperserConfig {
-  repeated uint32 custom_quorum_numbers = 1;
   optional string disperser_rpc = 3;
   optional int32 eth_confirmation_depth = 4;
   optional string eigenda_eth_rpc = 5;

--- a/core/node/da_clients/Cargo.toml
+++ b/core/node/da_clients/Cargo.toml
@@ -65,3 +65,4 @@ ethabi = "16.0.0"
 rust-kzg-bn254 = {git = "https://github.com/lambdaclass/rust-kzg-bn254", branch = "bump-ark"}
 ark-bn254 = "0.5.0-alpha.0"
 num-bigint = "0.4.6"
+serial_test = "3.1.1"

--- a/core/node/da_clients/src/eigen/client.rs
+++ b/core/node/da_clients/src/eigen/client.rs
@@ -110,8 +110,10 @@ mod tests {
 
     use super::*;
     use crate::eigen::blob_info::BlobInfo;
+    use serial_test::serial;
 
     #[tokio::test]
+    #[serial]
     async fn test_non_auth_dispersal() {
         let config = EigenConfig::Disperser(DisperserConfig {
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
@@ -150,6 +152,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_auth_dispersal() {
         let config = EigenConfig::Disperser(DisperserConfig {
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
@@ -220,6 +223,7 @@ mod tests {
         assert_eq!(retrieved_data.unwrap(), data);
     }
     #[tokio::test]
+    #[serial]
     async fn test_wait_for_finalization() {
         let config = EigenConfig::Disperser(DisperserConfig {
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
@@ -284,9 +288,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_eth_confirmation_depth() {
         let config = EigenConfig::Disperser(DisperserConfig {
-            custom_quorum_numbers: None,
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             eth_confirmation_depth: 5,
             eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
@@ -323,9 +327,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_auth_dispersal_eth_confirmation_depth() {
         let config = EigenConfig::Disperser(DisperserConfig {
-            custom_quorum_numbers: None,
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             eth_confirmation_depth: 5,
             eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),

--- a/core/node/da_clients/src/eigen/client.rs
+++ b/core/node/da_clients/src/eigen/client.rs
@@ -114,7 +114,6 @@ mod tests {
     #[tokio::test]
     async fn test_non_auth_dispersal() {
         let config = EigenConfig::Disperser(DisperserConfig {
-            custom_quorum_numbers: None,
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             eth_confirmation_depth: -1,
             eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
@@ -153,7 +152,6 @@ mod tests {
     #[tokio::test]
     async fn test_auth_dispersal() {
         let config = EigenConfig::Disperser(DisperserConfig {
-            custom_quorum_numbers: None,
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             eth_confirmation_depth: -1,
             eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
@@ -224,7 +222,6 @@ mod tests {
     #[tokio::test]
     async fn test_wait_for_finalization() {
         let config = EigenConfig::Disperser(DisperserConfig {
-            custom_quorum_numbers: None,
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             blob_size_limit: 2 * 1024 * 1024, // 2MB
             status_query_timeout: 1800000,    // 30 minutes


### PR DESCRIPTION
## What ❔
This PR removes the config parameter custom quorum numbers for the disperser, which is not used anywhere
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
