### PR TITLE
Eigenda invert sidecar communication

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -13178,7 +13178,6 @@ dependencies = [
  "blake2b_simd",
  "bytes",
  "celestia-types",
- "ethabi",
  "flate2",
  "futures 0.3.31",
  "hex",
@@ -13207,10 +13206,8 @@ dependencies = [
  "zksync_config",
  "zksync_da_client",
  "zksync_env_config",
- "zksync_eth_client",
  "zksync_object_store",
  "zksync_types",
- "zksync_web3_decl",
 ]
 
 [[package]]

--- a/core/lib/config/src/configs/da_client/eigenv2m1.rs
+++ b/core/lib/config/src/configs/da_client/eigenv2m1.rs
@@ -18,14 +18,14 @@ pub struct EigenConfigV2M1 {
     pub eigenda_eth_rpc: Option<SensitiveUrl>,
     /// Authenticated dispersal
     pub authenticated: bool,
-    /// Address of the eigenDA registry contract
-    pub eigenda_cert_and_blob_verifier_addr: Address,
     /// Address of the EigenDA cert verifier
     pub cert_verifier_addr: Address,
     /// Blob version
     pub blob_version: u16,
     /// Polynomial form to disperse the blobs
     pub polynomial_form: PolynomialForm,
+    /// URL of the EigenDA Sidecar RPC server
+    pub eigenda_sidecar_rpc: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/core/lib/env_config/src/da_client.rs
+++ b/core/lib/env_config/src/da_client.rs
@@ -114,10 +114,6 @@ pub fn da_client_config_from_env(prefix: &str) -> anyhow::Result<DAClientConfig>
                 Err(_) => None,
             },
             authenticated: env::var(format!("{}AUTHENTICATED", prefix))?.parse()?,
-            eigenda_cert_and_blob_verifier_addr: H160::from_str(&env::var(format!(
-                "{}EIGENDA_CERT_AND_BLOB_VERIFIER_ADDR",
-                prefix
-            ))?)?,
             cert_verifier_addr: H160::from_str(&env::var(format!(
                 "{}CERT_VERIFIER_ADDR",
                 prefix
@@ -128,6 +124,7 @@ pub fn da_client_config_from_env(prefix: &str) -> anyhow::Result<DAClientConfig>
                 "Poly" => zksync_config::configs::da_client::eigenv2m1::PolynomialForm::Eval,
                 _ => anyhow::bail!("Unknown polynomial form"),
             },
+            eigenda_sidecar_rpc: env::var(format!("{}EIGENDA_SIDECAR_RPC", prefix))?,
         }),
         OBJECT_STORE_CLIENT_CONFIG_NAME => {
             DAClientConfig::ObjectStore(envy_load("da_object_store", prefix)?)
@@ -435,10 +432,10 @@ mod tests {
             DA_DISPERSER_RPC="http://localhost:8080"
             DA_EIGENDA_ETH_RPC="http://localhost:8545"
             DA_AUTHENTICATED=false
-            DA_EIGENDA_CERT_AND_BLOB_VERIFIER_ADDR="0x0000000000000000000000000000000000001234"
             DA_CERT_VERIFIER_ADDR="0x0000000000000000000000000000000000012345"
             DA_BLOB_VERSION="0"
             DA_POLYNOMIAL_FORM="Coeff"
+            DA_EIGENDA_SIDECAR_RPC="http://localhost:8081"
         "#;
         lock.set_env(config);
 
@@ -449,15 +446,13 @@ mod tests {
                 disperser_rpc: "http://localhost:8080".to_string(),
                 eigenda_eth_rpc: Some(SensitiveUrl::from_str("http://localhost:8545").unwrap()),
                 authenticated: false,
-                eigenda_cert_and_blob_verifier_addr: "0x0000000000000000000000000000000000001234"
-                    .parse()
-                    .unwrap(),
                 cert_verifier_addr: "0x0000000000000000000000000000000000012345"
                     .parse()
                     .unwrap(),
                 blob_version: 0,
                 polynomial_form:
                     zksync_config::configs::da_client::eigenv2m1::PolynomialForm::Coeff,
+                eigenda_sidecar_rpc: "http://localhost:8081".to_string(),
             })
         );
     }

--- a/core/lib/protobuf_config/src/da_client.rs
+++ b/core/lib/protobuf_config/src/da_client.rs
@@ -124,14 +124,9 @@ impl ProtoRepr for proto::DataAvailabilityClient {
                         .transpose()
                         .context("eigenda_eth_rpc")?,
                     authenticated: *required(&conf.authenticated).context("authenticated")?,
-                    eigenda_cert_and_blob_verifier_addr: required(
-                        &conf.eigenda_cert_and_blob_verifier_addr,
-                    )
-                    .and_then(|x| parse_h160(x))
-                    .context("eigenda_cert_and_blob_verifier_addr")?,
                     cert_verifier_addr: required(&conf.cert_verifier_addr)
                         .and_then(|x| parse_h160(x))
-                        .context("eigenda_cert_and_blob_verifier_addr")?,
+                        .context("eigenda_cert_verifier_addr")?,
                     blob_version: *required(&conf.blob_version).context("blob_version")? as u16,
                     polynomial_form: match required(&conf.polynomial_form)
                         .and_then(|x| Ok(crate::proto::da_client::PolynomialForm::try_from(*x)?))
@@ -144,6 +139,9 @@ impl ProtoRepr for proto::DataAvailabilityClient {
                             configs::da_client::eigenv2m1::PolynomialForm::Eval
                         }
                     },
+                    eigenda_sidecar_rpc: required(&conf.eigenda_sidecar_rpc)
+                        .context("eigenda_sidecar_rpc")?
+                        .clone(),
                 })
             }
             proto::data_availability_client::Config::Eigenv2m0(conf) => {
@@ -160,7 +158,7 @@ impl ProtoRepr for proto::DataAvailabilityClient {
                     authenticated: *required(&conf.authenticated).context("authenticated")?,
                     cert_verifier_addr: required(&conf.cert_verifier_addr)
                         .and_then(|x| parse_h160(x))
-                        .context("eigenda_cert_and_blob_verifier_addr")?,
+                        .context("eigenda_cert_verifier_addr")?,
                     blob_version: *required(&conf.blob_version).context("blob_version")? as u16,
                     polynomial_form: match required(&conf.polynomial_form)
                         .and_then(|x| Ok(crate::proto::da_client::PolynomialForm::try_from(*x)?))
@@ -258,10 +256,6 @@ impl ProtoRepr for proto::DataAvailabilityClient {
                         .as_ref()
                         .map(|a| a.expose_str().to_string()),
                     authenticated: Some(config.authenticated),
-                    eigenda_cert_and_blob_verifier_addr: Some(format!(
-                        "{:?}",
-                        config.eigenda_cert_and_blob_verifier_addr
-                    )),
                     cert_verifier_addr: Some(format!("{:?}", config.cert_verifier_addr)),
                     blob_version: Some(config.blob_version as u32),
                     polynomial_form: Some(match config.polynomial_form {
@@ -272,6 +266,7 @@ impl ProtoRepr for proto::DataAvailabilityClient {
                             crate::proto::da_client::PolynomialForm::Eval.into()
                         }
                     }),
+                    eigenda_sidecar_rpc: Some(config.eigenda_sidecar_rpc.clone()),
                 })
             }
             EigenV2M0(config) => {

--- a/core/lib/protobuf_config/src/proto/config/da_client.proto
+++ b/core/lib/protobuf_config/src/proto/config/da_client.proto
@@ -71,7 +71,7 @@ message EigenConfigV2M1 {
   optional string cert_verifier_addr = 12;
   optional uint32 blob_version = 13;
   optional PolynomialForm polynomial_form = 14; 
-  optional string eigenda_cert_and_blob_verifier_addr = 15;
+  optional string eigenda_sidecar_rpc = 15;
   reserved 1,2,4,6,7,9,10,11;
   reserved "rpc_node_url","inclusion_polling_interval_ms", "settlement_layer_confirmation_depth", "eigenda_svc_manager_address","wait_for_finalization", "points_source_path", "points_source_url","custom_quorum_numbers";
 }

--- a/core/node/da_clients/Cargo.toml
+++ b/core/node/da_clients/Cargo.toml
@@ -59,6 +59,3 @@ pbjson-types.workspace = true
 rust-eigenda-v2-client.workspace = true
 rust-eigenda-v2-common.workspace = true
 rust-eigenda-client.workspace = true
-zksync_web3_decl.workspace = true
-ethabi.workspace = true
-zksync_eth_client.workspace = true

--- a/core/node/da_clients/src/eigenv2m1/README.md
+++ b/core/node/da_clients/src/eigenv2m1/README.md
@@ -18,7 +18,7 @@ These are the fields that can be modified:
 - `cert_verifier_addr` Address of the eigenDA cert verifier contract
 - `blob_version` Blob Version used by eigenDA, currently only blob version 0 is supported
 - `polynomial_form` Polynomial form used to encode data, either COEFF or EVAL
-- `eigenda_cert_and_blob_verifier_addr` Address of the eigenda cert and blob verifier contract
+- `eigenda_sidecar_rpc` RPC of the EigenDA Sidecar that generates the proofs
 
 So, for example, a client setup that uses the holesky EigenDA client would look like this:
 
@@ -30,7 +30,7 @@ eigenv2m1:
   cert_verifier_addr: 0xfe52fe1940858dcb6e12153e2104ad0fdfbe1162
   blob_version: 0
   polynomial_form: COEFF
-  eigenda_cert_and_blob_verifier_addr: 0xA9F8693aeA4ce4b1A334d490b038EC2D805FA69a
+  eigenda_sidecar_rpc: http://localhost:9999
 ```
 
 You also need to modify `etc/env/file_based/secrets.yaml` to include the private key of the account that will be used.

--- a/core/node/da_clients/src/eigenv2m1/client.rs
+++ b/core/node/da_clients/src/eigenv2m1/client.rs
@@ -95,7 +95,7 @@ impl EigenDAClientV2M1 {
             .await
             .map_err(|_| anyhow::anyhow!("Failed to parse response"))?;
 
-        if !json_response.get("error").is_none() {
+        if json_response.get("error").is_some() {
             Err(anyhow::anyhow!("Failed to send blob key"))
         } else {
             Ok(())
@@ -176,7 +176,7 @@ impl DataAvailabilityClient for EigenDAClientV2M1 {
             .get_inclusion_data(&blob_key)
             .await
             .map_err(to_retriable_da_error)?;
-        if let Some(_) = eigenda_cert {
+        if eigenda_cert.is_some() {
             if let Some(proof) = self
                 .get_proof(blob_id)
                 .await

--- a/core/node/da_clients/src/eigenv2m1/client.rs
+++ b/core/node/da_clients/src/eigenv2m1/client.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use ethabi::{encode, ParamType, Token};
+use reqwest::Client;
 use rust_eigenda_v2_client::{
     core::BlobKey,
     payload_disperser::{PayloadDisperser, PayloadDisperserConfig},
@@ -8,9 +8,9 @@ use rust_eigenda_v2_client::{
     utils::SecretUrl,
 };
 use rust_eigenda_v2_common::{Payload, PayloadForm};
+use serde_json::json;
 use subxt_signer::ExposeSecret;
 use url::Url;
-use zksync_basic_types::web3::CallRequest;
 use zksync_config::{
     configs::da_client::eigenv2m1::{EigenSecretsV2M1, PolynomialForm},
     EigenConfigV2M1,
@@ -19,9 +19,6 @@ use zksync_da_client::{
     types::{ClientType, DAError, DispatchResponse, FinalityResponse, InclusionData},
     DataAvailabilityClient,
 };
-use zksync_eth_client::EthInterface;
-use zksync_types::Address;
-use zksync_web3_decl::client::{Client, DynClient, L1};
 
 use crate::utils::{to_non_retriable_da_error, to_retriable_da_error};
 
@@ -29,8 +26,8 @@ use crate::utils::{to_non_retriable_da_error, to_retriable_da_error};
 #[derive(Debug, Clone)]
 pub struct EigenDAClientV2M1 {
     client: PayloadDisperser,
-    eth_call_client: Box<DynClient<L1>>,
-    eigenda_cert_and_blob_verifier_addr: Address,
+    sidecar_client: Client,
+    sidecar_rpc: String,
 }
 
 impl EigenDAClientV2M1 {
@@ -69,78 +66,56 @@ impl EigenDAClientV2M1 {
             .await
             .map_err(|e| anyhow::anyhow!("Eigen client Error: {:?}", e))?;
 
-        let eth_call_client: Client<L1> = Client::http(
-            config
-                .eigenda_eth_rpc
-                .ok_or(anyhow::anyhow!("Eigenda eth rpc url is not set"))?,
-        )
-        .map_err(|e| anyhow::anyhow!("Query client Error: {:?}", e))?
-        .build();
-        let eth_call_client = Box::new(eth_call_client) as Box<DynClient<L1>>;
         Ok(Self {
             client,
-            eth_call_client,
-            eigenda_cert_and_blob_verifier_addr: config.eigenda_cert_and_blob_verifier_addr,
+            sidecar_client: Client::new(),
+            sidecar_rpc: config.eigenda_sidecar_rpc,
         })
     }
 }
 
 impl EigenDAClientV2M1 {
-    /// This function checks a mapping with form
-    /// `mapping(bytes) -> bool` in the EigenDA registry contract.
-    /// The name of the mapping is passed as a parameter.
-    async fn check_mapping(&self, inclusion_data: &[u8], mapping: &str) -> Result<bool, DAError> {
-        let mut data = vec![];
-        let func_selector = ethabi::short_signature(mapping, &[ParamType::Bytes]).to_vec();
-        data.extend_from_slice(&func_selector);
-        let inclusion_data = encode(&[Token::Bytes(inclusion_data.to_owned())]);
-        data.extend_from_slice(&inclusion_data);
-        let call_request = CallRequest {
-            to: Some(self.eigenda_cert_and_blob_verifier_addr),
-            data: Some(zksync_basic_types::web3::Bytes(data)),
-            ..Default::default()
-        };
-
-        let block_id = self
-            .eth_call_client
-            .block_number()
+    async fn send_blob_key(&self, blob_key: String) -> anyhow::Result<()> {
+        let url = format!("{}/generate_proof", self.sidecar_rpc);
+        let body = json!({
+            "blob_id": blob_key,
+        });
+        let response = self
+            .sidecar_client
+            .post(&url)
+            .json(&body)
+            .send()
             .await
-            .map_err(to_retriable_da_error)?;
-        let res = self
-            .eth_call_client
-            .as_ref()
-            .call_contract_function(call_request, Some(block_id.into()))
-            .await
-            .map_err(to_retriable_da_error)?;
-        match hex::encode(res.0).as_str() {
-            "0000000000000000000000000000000000000000000000000000000000000000" => Ok(false),
-            "0000000000000000000000000000000000000000000000000000000000000001" => Ok(true),
-            _ => Err(anyhow::anyhow!("Invalid response from {}", mapping))
-                .map_err(to_non_retriable_da_error),
+            .map_err(|_| anyhow::anyhow!("Failed to send blob key"))?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("Failed to send blob key"))
         }
     }
 
-    async fn check_finished_batches(&self, inclusion_data: &[u8]) -> Result<bool, DAError> {
-        self.check_mapping(inclusion_data, "finishedBatches").await
-    }
+    async fn get_proof(&self, blob_key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        let url = format!("{}/get_proof", self.sidecar_rpc);
+        let body = json!({
+            "blob_id": blob_key,
+        });
+        let response = self
+            .sidecar_client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|_| anyhow::anyhow!("Failed to get proof"))?;
 
-    async fn check_verified_batches(&self, inclusion_data: &[u8]) -> Result<bool, DAError> {
-        self.check_mapping(inclusion_data, "verifiedBatches").await
-    }
-
-    /// Checks into the EigenDARegistry contract if for the given inclusion data the proof was correctly verified.
-    /// It first checks if the proof generation finished, and if it did, it checks if the proof was verified.
-    /// If the proof generation didn't finish, it will be called again later when the dispatcher attemps to get inclusion data again
-    async fn check_inclusion_data_verification(
-        &self,
-        inclusion_data: &[u8],
-    ) -> Result<Option<bool>, DAError> {
-        let finished = self.check_finished_batches(inclusion_data).await?;
-        if !finished {
-            return Ok(None);
+        if response.status().is_success() {
+            let proof: Vec<u8> = response
+                .json()
+                .await
+                .map_err(|_| anyhow::anyhow!("Failed to parse proof"))?;
+            return Ok(Some(proof));
         }
-        let verified = self.check_verified_batches(inclusion_data).await?;
-        Ok(Some(verified))
+
+        Ok(None)
     }
 }
 
@@ -158,7 +133,13 @@ impl DataAvailabilityClient for EigenDAClientV2M1 {
             .await
             .map_err(to_retriable_da_error)?;
 
-        Ok(DispatchResponse::from(blob_key.to_hex()))
+        let blob_key_hex = blob_key.to_hex();
+
+        self.send_blob_key(blob_key_hex.clone())
+            .await
+            .map_err(to_non_retriable_da_error)?;
+
+        Ok(DispatchResponse::from(blob_key_hex))
     }
 
     async fn ensure_finality(
@@ -180,23 +161,13 @@ impl DataAvailabilityClient for EigenDAClientV2M1 {
             .get_inclusion_data(&blob_key)
             .await
             .map_err(to_retriable_da_error)?;
-        if let Some(eigenda_cert) = eigenda_cert {
-            let inclusion_data = eigenda_cert
-                .to_bytes()
-                .map_err(|_| anyhow::anyhow!("Failed to convert eigenda cert to bytes"))
-                .map_err(to_non_retriable_da_error)?;
-            if let Some(verified) = self
-                .check_inclusion_data_verification(&inclusion_data)
-                .await?
+        if let Some(_) = eigenda_cert {
+            if let Some(proof) = self
+                .get_proof(blob_id)
+                .await
+                .map_err(to_retriable_da_error)?
             {
-                if verified {
-                    Ok(Some(InclusionData {
-                        data: inclusion_data,
-                    }))
-                } else {
-                    Err(anyhow::anyhow!("Inclusion data is not verified"))
-                        .map_err(to_non_retriable_da_error)
-                }
+                Ok(Some(InclusionData { data: proof }))
             } else {
                 Ok(None)
             }

--- a/core/node/da_clients/src/eigenv2m1/client.rs
+++ b/core/node/da_clients/src/eigenv2m1/client.rs
@@ -95,7 +95,7 @@ impl EigenDAClientV2M1 {
             .await
             .map_err(|_| anyhow::anyhow!("Failed to parse response"))?;
 
-        if let Some(error) = json_response.get("error") {
+        if !json_response.get("error").is_none() {
             Err(anyhow::anyhow!("Failed to send blob key"))
         } else {
             Ok(())

--- a/zkstack_cli/crates/config/src/contracts.rs
+++ b/zkstack_cli/crates/config/src/contracts.rs
@@ -119,10 +119,10 @@ impl ContractsConfig {
                 .deployed_addresses
                 .eigenda_l1_validator_addr,
         );
-        self.l1.eigenda_cert_and_blob_verifier_addr = Some(
+        self.l1.eigenda_risc_zero_verifier_addr = Some(
             deploy_l1_output
                 .deployed_addresses
-                .eigenda_cert_and_blob_verifier_addr,
+                .eigenda_risc_zero_verifier_addr,
         );
         self.l1.chain_admin_addr = deploy_l1_output.deployed_addresses.chain_admin;
         self.ecosystem_contracts.server_notifier_proxy_addr = Some(
@@ -277,7 +277,7 @@ pub struct L1Contracts {
     pub transaction_filterer_addr: Option<Address>,
     // `Option` to be able to parse configs from previous protocol version
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub eigenda_cert_and_blob_verifier_addr: Option<Address>,
+    pub eigenda_risc_zero_verifier_addr: Option<Address>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/input.rs
@@ -196,8 +196,7 @@ impl DeployL1Config {
                     .validator_timelock_execution_delay,
                 avail_l1_da_validator_addr: l1_network.avail_l1_da_validator_addr(),
                 eigenda_l1_validator_addr: l1_network.eigenda_l1_validator_addr(),
-                eigenda_cert_and_blob_verifier_addr: l1_network
-                    .eigenda_cert_and_blob_verifier_addr(),
+                eigenda_risc_zero_verifier_addr: l1_network.eigenda_risc_zero_verifier_addr(),
             },
             tokens: TokensDeployL1Config {
                 token_weth_address: initial_deployment_config.token_weth_address,
@@ -237,7 +236,7 @@ pub struct ContractsDeployL1Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eigenda_l1_validator_addr: Option<Address>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub eigenda_cert_and_blob_verifier_addr: Option<Address>,
+    pub eigenda_risc_zero_verifier_addr: Option<Address>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/output.rs
@@ -37,7 +37,7 @@ pub struct DeployL1DeployedAddressesOutput {
     pub no_da_validium_l1_validator_addr: Address,
     pub avail_l1_da_validator_addr: Address,
     pub eigenda_l1_validator_addr: Address,
-    pub eigenda_cert_and_blob_verifier_addr: Address,
+    pub eigenda_risc_zero_verifier_addr: Address,
     pub l1_rollup_da_manager: Address,
     pub native_token_vault_addr: Address,
     pub server_notifier_proxy_addr: Address,

--- a/zkstack_cli/crates/types/src/l1_network.rs
+++ b/zkstack_cli/crates/types/src/l1_network.rs
@@ -60,7 +60,7 @@ impl L1Network {
         }
     }
 
-    pub fn eigenda_cert_and_blob_verifier_addr(&self) -> Option<Address> {
+    pub fn eigenda_risc_zero_verifier_addr(&self) -> Option<Address> {
         match self {
             L1Network::Localhost => None,
             L1Network::Sepolia | L1Network::Holesky => {


### PR DESCRIPTION
## What ❔
This PR inverts the communication with the sidecar, it now calls the 2 sidecar endpoints `generate_proof` and `get_proof`.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
