### PR TITLE
Remove `V2Secure` sufix from `EigenDA` option

### DIFF
--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -583,18 +583,6 @@ impl MainNodeBuilder {
                     config.eigenda_eth_rpc = l1_secrets.l1_rpc_url.clone();
                 }
 
-                if config.eigenda_prover_service_rpc.is_none() {
-                    let use_dummy_inclusion_data = self
-                        .configs
-                        .da_dispatcher_config
-                        .clone()
-                        .context("No config for DA dispatcher")?
-                        .use_dummy_inclusion_data;
-                    if !use_dummy_inclusion_data {
-                        bail!("If EigenDA prover service RPC is not configured, use_dummy_inclusion_data should be set.");
-                    }
-                }
-
                 self.node.add_layer(EigenWiringLayer::new(config, secret));
             }
             _ => bail!("invalid pair of da_client and da_secrets"),

--- a/core/node/da_clients/src/eigen/README.md
+++ b/core/node/da_clients/src/eigen/README.md
@@ -17,6 +17,7 @@ Then set up the client by modifying the field `da_client`, add the following fie
 - `operator_state_retriever_addr` Address of the Eigen operator state retriever contract
 - `registry_coordinator_addr` Address of the Eigen registry coordinator contract
 - `blob_version` Blob Version used by eigenDA, currently only blob version 0 is supported
+- `eigenda_prover_service_rpc` RPC of the EigenDA prover service that generates the proofs
 
 You also need to modify `etc/env/file_based/secrets.yaml` to include the private key of the account that will be used.
 You need to add the following field:
@@ -29,38 +30,7 @@ da_client:
 
 > Note: the private key should be in hex format, without the `0x` prefix.
 
-### V2 client configuration
-
-A client setup that uses the holesky EigenDA non-secure V2 client would look like this:
-
-`etc/env/file_based/overrides/validium.yaml`:
-
-```yaml
-da_dispatcher:
-  use_dummy_inclusion_data: true
-da_client:
-  client: Eigen
-  disperser_rpc: https://disperser-testnet-holesky.eigenda.xyz
-  eigenda_eth_rpc: https://ethereum-holesky-rpc.publicnode.com
-  cert_verifier_router_addr: 0xdd735affe77a5ed5b21ed47219f95ed841f8ffbd
-  operator_state_retriever_addr: 0xB4baAfee917fb4449f5ec64804217bccE9f46C67
-  registry_coordinator_addr: 0x53012C69A189cfA2D9d29eb6F19B32e0A2EA3490
-  blob_version: 0
-```
-
-Then, when running `zkstack ecosystem init` set the validium parameter as follows:
-
-```bash
---validium-type no-da
-```
-
-### V2Secure specific client configuration
-
-A V2 Secure client uses the same fields as the `V2` Version, and adds a new field:
-
-- `eigenda_prover_service_rpc` RPC of the EigenDA prover service that generates the proofs
-
-And a client setup that uses the holesky EigenDA V2 Secure client would look like this:
+A client setup that uses the holesky EigenDA V2 client would look like this:
 
 `etc/env/file_based/overrides/validium.yaml`:
 
@@ -77,8 +47,6 @@ da_client:
   blob_version: 0
   eigenda_prover_service_rpc: http://localhost:9999
 ```
-
-> Note: The `eigenda_prover_service_rpc` field determines wheter the client will use secure mode or not.
 
 Then, when running `zkstack ecosystem init` set the validium parameter as follows:
 

--- a/core/node/da_clients/src/eigen/README.md
+++ b/core/node/da_clients/src/eigen/README.md
@@ -48,6 +48,12 @@ da_client:
   blob_version: 0
 ```
 
+Then, when running `zkstack ecosystem init` set the validium parameter as follows:
+
+```bash
+--validium-type no-da
+```
+
 ### V2Secure specific client configuration
 
 A V2 Secure client uses the same fields as the `V2` Version, and adds a new field:
@@ -73,3 +79,9 @@ da_client:
 ```
 
 > Note: The `eigenda_prover_service_rpc` field determines wheter the client will use secure mode or not.
+
+Then, when running `zkstack ecosystem init` set the validium parameter as follows:
+
+```bash
+--validium-type eigen-da
+```

--- a/zkstack_cli/crates/config/src/chain.rs
+++ b/zkstack_cli/crates/config/src/chain.rs
@@ -73,8 +73,8 @@ pub enum DAValidatorType {
     Rollup = 0,
     NoDA = 1,
     Avail = 2,
-    EigenDA = 3,
-    EigenDAV2Secure = 4,
+    EigenDAOLDREMOVE = 3,
+    EigenDA = 4,
 }
 
 impl Serialize for ChainConfig {

--- a/zkstack_cli/crates/config/src/chain.rs
+++ b/zkstack_cli/crates/config/src/chain.rs
@@ -73,8 +73,7 @@ pub enum DAValidatorType {
     Rollup = 0,
     NoDA = 1,
     Avail = 2,
-    EigenDAOLDREMOVE = 3,
-    EigenDA = 4,
+    EigenDA = 3,
 }
 
 impl Serialize for ChainConfig {

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/input.rs
@@ -53,7 +53,6 @@ async fn get_da_validator_type(config: &ChainConfig) -> anyhow::Result<DAValidat
         (L1BatchCommitmentMode::Rollup, _) => Ok(DAValidatorType::Rollup),
         (L1BatchCommitmentMode::Validium, None | Some("NoDA")) => Ok(DAValidatorType::NoDA),
         (L1BatchCommitmentMode::Validium, Some("Avail")) => Ok(DAValidatorType::Avail),
-        (L1BatchCommitmentMode::Validium, Some("EigenDAOLDREMOVE")) => Ok(DAValidatorType::NoDA),
         (L1BatchCommitmentMode::Validium, Some("EigenDA")) => Ok(DAValidatorType::EigenDA),
         _ => anyhow::bail!("DAValidatorType is not supported"),
     }

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/input.rs
@@ -53,10 +53,8 @@ async fn get_da_validator_type(config: &ChainConfig) -> anyhow::Result<DAValidat
         (L1BatchCommitmentMode::Rollup, _) => Ok(DAValidatorType::Rollup),
         (L1BatchCommitmentMode::Validium, None | Some("NoDA")) => Ok(DAValidatorType::NoDA),
         (L1BatchCommitmentMode::Validium, Some("Avail")) => Ok(DAValidatorType::Avail),
-        (L1BatchCommitmentMode::Validium, Some("Eigen")) => Ok(DAValidatorType::NoDA),
-        (L1BatchCommitmentMode::Validium, Some("EigenDAV2Secure")) => {
-            Ok(DAValidatorType::EigenDAV2Secure)
-        }
+        (L1BatchCommitmentMode::Validium, Some("EigenDAOLDREMOVE")) => Ok(DAValidatorType::NoDA),
+        (L1BatchCommitmentMode::Validium, Some("EigenDA")) => Ok(DAValidatorType::EigenDA),
         _ => anyhow::bail!("DAValidatorType is not supported"),
     }
 }

--- a/zkstack_cli/crates/config/src/general.rs
+++ b/zkstack_cli/crates/config/src/general.rs
@@ -255,8 +255,8 @@ impl GeneralConfigPatch {
         Ok(())
     }
 
-    pub fn set_eigendav2secure_client(&mut self) -> anyhow::Result<()> {
-        self.0.insert("da_client.client", "EigenDAV2Secure")?;
+    pub fn set_eigenda_client(&mut self) -> anyhow::Result<()> {
+        self.0.insert("da_client.client", "EigenDA")?;
         Ok(())
     }
 

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/init/da_configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/init/da_configs.rs
@@ -28,8 +28,8 @@ pub struct ValidiumTypeArgs {
 pub enum ValidiumTypeInternal {
     NoDA,
     Avail,
+    EigenDAOLDREMOVE,
     EigenDA,
-    EigenDAV2Secure,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, EnumIter, Display, ValueEnum)]
@@ -42,15 +42,15 @@ pub enum AvailClientTypeInternal {
 pub enum ValidiumType {
     NoDA,
     Avail((AvailConfig, AvailSecrets)),
+    EigenDAOLDREMOVE,
     EigenDA,
-    EigenDAV2Secure,
 }
 
 impl ValidiumType {
     pub fn read() -> Self {
         match PromptSelect::new(MSG_VALIDIUM_TYPE_PROMPT, ValidiumTypeInternal::iter()).ask() {
+            ValidiumTypeInternal::EigenDAOLDREMOVE => ValidiumType::EigenDAOLDREMOVE, // EigenDA doesn't support configuration through CLI
             ValidiumTypeInternal::EigenDA => ValidiumType::EigenDA, // EigenDA doesn't support configuration through CLI
-            ValidiumTypeInternal::EigenDAV2Secure => ValidiumType::EigenDAV2Secure, // EigenDA doesn't support configuration through CLI
             ValidiumTypeInternal::NoDA => ValidiumType::NoDA,
             ValidiumTypeInternal::Avail => {
                 let avail_client_type = PromptSelect::new(

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/init/da_configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/init/da_configs.rs
@@ -28,7 +28,6 @@ pub struct ValidiumTypeArgs {
 pub enum ValidiumTypeInternal {
     NoDA,
     Avail,
-    EigenDAOLDREMOVE,
     EigenDA,
 }
 
@@ -42,14 +41,12 @@ pub enum AvailClientTypeInternal {
 pub enum ValidiumType {
     NoDA,
     Avail((AvailConfig, AvailSecrets)),
-    EigenDAOLDREMOVE,
     EigenDA,
 }
 
 impl ValidiumType {
     pub fn read() -> Self {
         match PromptSelect::new(MSG_VALIDIUM_TYPE_PROMPT, ValidiumTypeInternal::iter()).ask() {
-            ValidiumTypeInternal::EigenDAOLDREMOVE => ValidiumType::EigenDAOLDREMOVE, // EigenDA doesn't support configuration through CLI
             ValidiumTypeInternal::EigenDA => ValidiumType::EigenDA, // EigenDA doesn't support configuration through CLI
             ValidiumTypeInternal::NoDA => ValidiumType::NoDA,
             ValidiumTypeInternal::Avail => {

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/init/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/init/mod.rs
@@ -100,10 +100,10 @@ impl InitArgs {
                 Some(da_configs::ValidiumTypeInternal::Avail) => panic!(
                     "Avail is not supported via CLI args, use interactive mode" // TODO: Add support for configuration via CLI args
                 ),
-                Some(da_configs::ValidiumTypeInternal::EigenDA) => Some(ValidiumType::EigenDA),
-                Some(da_configs::ValidiumTypeInternal::EigenDAV2Secure) => {
-                    Some(ValidiumType::EigenDAV2Secure)
+                Some(da_configs::ValidiumTypeInternal::EigenDAOLDREMOVE) => {
+                    Some(ValidiumType::EigenDAOLDREMOVE)
                 }
+                Some(da_configs::ValidiumTypeInternal::EigenDA) => Some(ValidiumType::EigenDA),
             },
             _ => None,
         };

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/init/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/init/mod.rs
@@ -100,9 +100,6 @@ impl InitArgs {
                 Some(da_configs::ValidiumTypeInternal::Avail) => panic!(
                     "Avail is not supported via CLI args, use interactive mode" // TODO: Add support for configuration via CLI args
                 ),
-                Some(da_configs::ValidiumTypeInternal::EigenDAOLDREMOVE) => {
-                    Some(ValidiumType::EigenDAOLDREMOVE)
-                }
                 Some(da_configs::ValidiumTypeInternal::EigenDA) => Some(ValidiumType::EigenDA),
             },
             _ => None,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
@@ -85,11 +85,11 @@ pub async fn init_configs(
     })?;
 
     match &init_args.validium_config {
-        None | Some(ValidiumType::NoDA) | Some(ValidiumType::EigenDA) => {
+        None | Some(ValidiumType::NoDA) | Some(ValidiumType::EigenDAOLDREMOVE) => {
             general_config.remove_da_client();
         }
-        Some(ValidiumType::EigenDAV2Secure) => {
-            general_config.set_eigendav2secure_client()?;
+        Some(ValidiumType::EigenDA) => {
+            general_config.set_eigenda_client()?;
         }
         Some(ValidiumType::Avail((avail_config, _))) => {
             general_config.set_avail_client(avail_config)?;
@@ -121,8 +121,8 @@ pub async fn init_configs(
     match &init_args.validium_config {
         None
         | Some(ValidiumType::NoDA)
-        | Some(ValidiumType::EigenDA)
-        | Some(ValidiumType::EigenDAV2Secure) => { /* Do nothing */ }
+        | Some(ValidiumType::EigenDAOLDREMOVE)
+        | Some(ValidiumType::EigenDA) => { /* Do nothing */ }
         Some(ValidiumType::Avail((_, avail_secrets))) => {
             secrets.set_avail_secrets(avail_secrets)?;
         }

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
@@ -85,7 +85,7 @@ pub async fn init_configs(
     })?;
 
     match &init_args.validium_config {
-        None | Some(ValidiumType::NoDA) | Some(ValidiumType::EigenDAOLDREMOVE) => {
+        None | Some(ValidiumType::NoDA) => {
             general_config.remove_da_client();
         }
         Some(ValidiumType::EigenDA) => {
@@ -119,10 +119,7 @@ pub async fn init_configs(
     secrets.set_l1_rpc_url(init_args.l1_rpc_url.clone())?;
     secrets.set_consensus_keys(consensus_keys)?;
     match &init_args.validium_config {
-        None
-        | Some(ValidiumType::NoDA)
-        | Some(ValidiumType::EigenDAOLDREMOVE)
-        | Some(ValidiumType::EigenDA) => { /* Do nothing */ }
+        None | Some(ValidiumType::NoDA) | Some(ValidiumType::EigenDA) => { /* Do nothing */ }
         Some(ValidiumType::Avail((_, avail_secrets))) => {
             secrets.set_avail_secrets(avail_secrets)?;
         }

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
@@ -258,7 +258,6 @@ pub(crate) async fn get_l1_da_validator(chain_config: &ChainConfig) -> anyhow::R
             match general_config.da_client_type().as_deref() {
                 Some("Avail") => contracts_config.l1.avail_l1_da_validator_addr,
                 Some("NoDA") | None => contracts_config.l1.no_da_validium_l1_validator_addr,
-                Some("EigenDAOLDREMOVE") => contracts_config.l1.no_da_validium_l1_validator_addr,
                 Some("EigenDA") => contracts_config.l1.eigenda_l1_validator_addr,
                 Some(unsupported) => {
                     anyhow::bail!("DA client config is not supported: {unsupported:?}");

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
@@ -258,8 +258,8 @@ pub(crate) async fn get_l1_da_validator(chain_config: &ChainConfig) -> anyhow::R
             match general_config.da_client_type().as_deref() {
                 Some("Avail") => contracts_config.l1.avail_l1_da_validator_addr,
                 Some("NoDA") | None => contracts_config.l1.no_da_validium_l1_validator_addr,
-                Some("Eigen") => contracts_config.l1.no_da_validium_l1_validator_addr,
-                Some("EigenDAV2Secure") => contracts_config.l1.eigenda_l1_validator_addr,
+                Some("EigenDAOLDREMOVE") => contracts_config.l1.no_da_validium_l1_validator_addr,
+                Some("EigenDA") => contracts_config.l1.eigenda_l1_validator_addr,
                 Some(unsupported) => {
                     anyhow::bail!("DA client config is not supported: {unsupported:?}");
                 }


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
